### PR TITLE
Add Tests for Delete and Edit Meeting

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
@@ -30,8 +30,8 @@ public class EditMeetingCommand extends Command {
 
     public static final String COMMAND_WORD = "edit meeting";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the contact identified "
-            + "by the index number used in the displayed contact list. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the meeting identified "
+            + "by the index number used in the displayed meeting list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_TITLE + "TITLE] "
@@ -51,7 +51,7 @@ public class EditMeetingCommand extends Command {
 
     /**
      * @param index                 of the meeting in the filtered meeting list to edit
-     * @param editContactDescriptor details to edit the meeting with
+     * @param editMeetingDescriptor details to edit the meeting with
      */
     public EditMeetingCommand(Index index, EditMeetingDescriptor editMeetingDescriptor) {
         requireNonNull(index);
@@ -105,7 +105,7 @@ public class EditMeetingCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof EditContactCommand)) {
+        if (!(other instanceof EditMeetingCommand)) {
             return false;
         }
 

--- a/src/main/java/seedu/address/model/meeting/MeetingList.java
+++ b/src/main/java/seedu/address/model/meeting/MeetingList.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import seedu.address.model.contact.exceptions.ContactNotFoundException;
 import seedu.address.model.meeting.exceptions.DuplicateMeetingException;
 import seedu.address.model.meeting.exceptions.MeetingNotFoundException;
 
@@ -35,8 +34,8 @@ public class MeetingList implements Iterable<Meeting> {
     }
 
     /**
-     * Removes the equivalent contact from the list.
-     * The contact must exist in the list.
+     * Removes the equivalent meeting from the list.
+     * The meeting must exist in the list.
      */
     public void remove(Meeting toRemove) {
         requireNonNull(toRemove);
@@ -68,14 +67,14 @@ public class MeetingList implements Iterable<Meeting> {
     /**
      * Replaces the meeting {@code target} in the list with {@code editedMeeting}.
      * {@code target} must exist in the list.
-     * The contact identity of {@code editedMeeting} must not be the same as another existing meeting in the list.
+     * The meeting identity of {@code editedMeeting} must not be the same as another existing meeting in the list.
      */
     public void setMeeting(Meeting target, Meeting editedMeeting) {
         requireAllNonNull(target, editedMeeting);
 
         int index = internalList.indexOf(target);
         if (index == -1) {
-            throw new ContactNotFoundException();
+            throw new MeetingNotFoundException();
         }
 
         if (!target.equals(editedMeeting) && contains(editedMeeting)) {

--- a/src/main/java/seedu/address/storage/JsonAdaptedMeeting.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedMeeting.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.contact.Name;
 import seedu.address.model.meeting.Description;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.meeting.Place;
@@ -55,7 +54,7 @@ class JsonAdaptedMeeting {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Title.class.getSimpleName()));
         }
         if (!Title.isValidTitle(title)) {
-            throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
+            throw new IllegalValueException(Title.MESSAGE_CONSTRAINTS);
         }
         final Title modelTitle = new Title(title);
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -3,10 +3,14 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PLACE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
@@ -22,6 +26,7 @@ import seedu.address.model.contact.NameContainsKeywordsPredicate;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.meeting.TitleContainsKeywordsPredicate;
 import seedu.address.testutil.EditContactDescriptorBuilder;
+import seedu.address.testutil.EditMeetingDescriptorBuilder;
 
 /**
  * Contains helper methods for testing commands.
@@ -41,6 +46,17 @@ public class CommandTestUtil {
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
+    public static final String VALID_TITLE_ENG = "English";
+    public static final String VALID_TITLE_CHI = "Chinese";
+    public static final String VALID_TIME_ENG = "01/01/2023 00:00";
+    public static final String VALID_TIME_CHI = "01/01/2023 12:00";
+    public static final String VALID_PLACE_ENG = "Home";
+    public static final String VALID_PLACE_CHI = "School";
+    public static final String VALID_DESCRIPTION_ENG = "";
+    public static final String VALID_DESCRIPTION_CHI = "This is a description.";
+    public static final String VALID_NOTE_ENG = "Project";
+    public static final String VALID_NOTE_CHI = "Date";
+
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;
@@ -52,17 +68,32 @@ public class CommandTestUtil {
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
+    public static final String TITLE_DESC_ENG = " " + PREFIX_TITLE + VALID_TITLE_ENG;
+    public static final String TITLE_DESC_CHI = " " + PREFIX_TITLE + VALID_TITLE_CHI;
+    public static final String TIME_DESC_ENG = " " + PREFIX_TIME + VALID_TIME_ENG;
+    public static final String TIME_DESC_CHI = " " + PREFIX_TIME + VALID_TIME_CHI;
+    public static final String PLACE_DESC_ENG = " " + PREFIX_PLACE + VALID_PLACE_ENG;
+    public static final String PLACE_DESC_CHI = " " + PREFIX_PLACE + VALID_PLACE_CHI;
+    public static final String DESCRIPTION_DESC_ENG = " " + PREFIX_DESCRIPTION + VALID_DESCRIPTION_ENG;
+    public static final String DESCRIPTION_DESC_CHI = " " + PREFIX_DESCRIPTION + VALID_DESCRIPTION_CHI;
+
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 
+    public static final String INVALID_TITLE_DESC = " " + PREFIX_TITLE + "French&"; // '&' not allowed in titles
+    public static final String INVALID_TIME_DESC = " " + PREFIX_TIME + "1/1/2023 14:00"; // wrong date format
+    public static final String INVALID_PLACE_DESC = " " + PREFIX_PLACE + "Z00m@meeting"; // @ not allowed in place
+
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 
     public static final EditContactCommand.EditContactDescriptor DESC_AMY;
     public static final EditContactCommand.EditContactDescriptor DESC_BOB;
+    public static final EditMeetingCommand.EditMeetingDescriptor DESC_ENG;
+    public static final EditMeetingCommand.EditMeetingDescriptor DESC_CHI;
 
     static {
         DESC_AMY = new EditContactDescriptorBuilder().withName(VALID_NAME_AMY)
@@ -71,6 +102,10 @@ public class CommandTestUtil {
         DESC_BOB = new EditContactDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+        DESC_ENG = new EditMeetingDescriptorBuilder().withTitle(VALID_TITLE_ENG)
+                .withTime(VALID_TIME_ENG).withPlace(VALID_PLACE_ENG).withDescription(VALID_DESCRIPTION_ENG).build();
+        DESC_CHI = new EditMeetingDescriptorBuilder().withTitle(VALID_TITLE_CHI)
+                .withTime(VALID_TIME_CHI).withPlace(VALID_PLACE_CHI).withDescription(VALID_DESCRIPTION_CHI).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/DeleteMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteMeetingCommandTest.java
@@ -1,0 +1,120 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showMeetingAtIndex;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalMeetingsAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.meeting.Meeting;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code DeleteMeetingCommand}.
+ */
+public class DeleteMeetingCommandTest {
+
+    private Model model = new ModelManager(getTypicalMeetingsAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Meeting meetingToDelete = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
+        DeleteMeetingCommand deleteMeetingCommand = new DeleteMeetingCommand(INDEX_FIRST);
+
+        String expectedMessage = String.format(DeleteMeetingCommand.MESSAGE_DELETE_MEETING_SUCCESS,
+                Messages.formatMeeting(meetingToDelete));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteMeeting(meetingToDelete);
+
+        assertCommandSuccess(deleteMeetingCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredMeetingList().size() + 1);
+        DeleteMeetingCommand deleteMeetingCommand = new DeleteMeetingCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteMeetingCommand, model, Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showMeetingAtIndex(model, INDEX_FIRST);
+
+        Meeting meetingToDelete = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
+        DeleteMeetingCommand deleteMeetingCommand = new DeleteMeetingCommand(INDEX_FIRST);
+
+        String expectedMessage = String.format(DeleteMeetingCommand.MESSAGE_DELETE_MEETING_SUCCESS,
+                Messages.formatMeeting(meetingToDelete));
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteMeeting(meetingToDelete);
+        showNoMeeting(expectedModel);
+
+        assertCommandSuccess(deleteMeetingCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showMeetingAtIndex(model, INDEX_FIRST);
+
+        Index outOfBoundIndex = INDEX_SECOND;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getMeetingList().size());
+
+        DeleteMeetingCommand deleteMeetingCommand = new DeleteMeetingCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteMeetingCommand, model, Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteMeetingCommand deleteFirstCommand = new DeleteMeetingCommand(INDEX_FIRST);
+        DeleteMeetingCommand deleteSecondCommand = new DeleteMeetingCommand(INDEX_SECOND);
+
+        // same object -> returns true
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+
+        // same values -> returns true
+        DeleteMeetingCommand deleteFirstCommandCopy = new DeleteMeetingCommand(INDEX_FIRST);
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteFirstCommand.equals(null));
+
+        // different meeting -> returns false
+        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        DeleteMeetingCommand deleteMeetingCommand = new DeleteMeetingCommand(targetIndex);
+        String expected = DeleteMeetingCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        assertEquals(expected, deleteMeetingCommand.toString());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no one.
+     */
+    private void showNoMeeting(Model model) {
+        model.updateFilteredMeetingList(p -> false);
+
+        assertTrue(model.getFilteredMeetingList().isEmpty());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/EditMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditMeetingCommandTest.java
@@ -1,0 +1,189 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_CHI;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_ENG;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TIME_CHI;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TITLE_CHI;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showMeetingAtIndex;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalMeetingsAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.EditMeetingCommand.EditMeetingDescriptor;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.testutil.EditMeetingDescriptorBuilder;
+import seedu.address.testutil.MeetingBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for EditMeetingCommand.
+ */
+public class EditMeetingCommandTest {
+
+    private Model model = new ModelManager(getTypicalMeetingsAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        Meeting editedMeeting = new MeetingBuilder().build();
+        EditMeetingDescriptor descriptor = new EditMeetingDescriptorBuilder(editedMeeting).build();
+        EditMeetingCommand editMeetingCommand = new EditMeetingCommand(INDEX_FIRST, descriptor);
+
+        String expectedMessage = String.format(EditMeetingCommand.MESSAGE_EDIT_MEETING_SUCCESS,
+                Messages.formatMeeting(editedMeeting));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setMeeting(model.getFilteredMeetingList().get(0), editedMeeting);
+
+        assertCommandSuccess(editMeetingCommand, model, expectedMessage, expectedModel);
+    }
+
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        Index indexLastMeeting = Index.fromOneBased(model.getFilteredMeetingList().size());
+        Meeting lastMeeting = model.getFilteredMeetingList().get(indexLastMeeting.getZeroBased());
+
+        MeetingBuilder meetingInList = new MeetingBuilder(lastMeeting);
+        Meeting editedMeeting = meetingInList.withTitle(VALID_TITLE_CHI).withTime(VALID_TIME_CHI).build();
+
+        EditMeetingDescriptor descriptor = new EditMeetingDescriptorBuilder().withTitle(VALID_TITLE_CHI)
+                .withTime(VALID_TIME_CHI).build();
+        EditMeetingCommand editMeetingCommand = new EditMeetingCommand(indexLastMeeting, descriptor);
+
+        String expectedMessage = String.format(EditMeetingCommand.MESSAGE_EDIT_MEETING_SUCCESS,
+                Messages.formatMeeting(editedMeeting));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setMeeting(lastMeeting, editedMeeting);
+
+        assertCommandSuccess(editMeetingCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noFieldSpecifiedUnfilteredList_success() {
+        EditMeetingCommand editMeetingCommand = new EditMeetingCommand(INDEX_FIRST,
+                new EditMeetingDescriptor());
+        Meeting editedMeeting = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
+
+        String expectedMessage = String.format(EditMeetingCommand.MESSAGE_EDIT_MEETING_SUCCESS,
+                Messages.formatMeeting(editedMeeting));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        assertCommandSuccess(editMeetingCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showMeetingAtIndex(model, INDEX_FIRST);
+
+        Meeting meetingInFilteredList = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
+        Meeting editedMeeting = new MeetingBuilder(meetingInFilteredList).withTitle(VALID_TITLE_CHI).build();
+        EditMeetingCommand editMeetingCommand = new EditMeetingCommand(INDEX_FIRST,
+                new EditMeetingDescriptorBuilder().withTitle(VALID_TITLE_CHI).build());
+
+        String expectedMessage = String.format(EditMeetingCommand.MESSAGE_EDIT_MEETING_SUCCESS,
+                Messages.formatMeeting(editedMeeting));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setMeeting(model.getFilteredMeetingList().get(0), editedMeeting);
+
+        assertCommandSuccess(editMeetingCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_duplicateMeetingUnfilteredList_failure() {
+        Meeting firstMeeting = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
+        EditMeetingDescriptor descriptor = new EditMeetingDescriptorBuilder(firstMeeting).build();
+        EditMeetingCommand editMeetingCommand = new EditMeetingCommand(INDEX_SECOND, descriptor);
+
+        assertCommandFailure(editMeetingCommand, model, EditMeetingCommand.MESSAGE_DUPLICATE_MEETING);
+    }
+
+    @Test
+    public void execute_duplicateMeetingFilteredList_failure() {
+        showMeetingAtIndex(model, INDEX_FIRST);
+
+        // edit ,eeting in filtered list into a duplicate in address book
+        Meeting meetingInList = model.getAddressBook().getMeetingList().get(INDEX_SECOND.getZeroBased());
+        EditMeetingCommand editMeetingCommand = new EditMeetingCommand(INDEX_FIRST,
+                new EditMeetingDescriptorBuilder(meetingInList).build());
+
+        assertCommandFailure(editMeetingCommand, model, EditMeetingCommand.MESSAGE_DUPLICATE_MEETING);
+    }
+
+    @Test
+    public void execute_invalidMeetingIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredMeetingList().size() + 1);
+        EditMeetingDescriptor descriptor = new EditMeetingDescriptorBuilder().withTitle(VALID_TITLE_CHI).build();
+        EditMeetingCommand editMeetingCommand = new EditMeetingCommand(outOfBoundIndex, descriptor);
+
+        assertCommandFailure(editMeetingCommand, model, Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of address book
+     */
+    @Test
+    public void execute_invalidMeetingIndexFilteredList_failure() {
+        showMeetingAtIndex(model, INDEX_FIRST);
+        Index outOfBoundIndex = INDEX_SECOND;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getMeetingList().size());
+
+        EditMeetingCommand editMeetingCommand = new EditMeetingCommand(outOfBoundIndex,
+                new EditMeetingDescriptorBuilder().withTitle(VALID_TITLE_CHI).build());
+
+        assertCommandFailure(editMeetingCommand, model, Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+    }
+
+
+    @Test
+    public void equals() {
+        final EditMeetingCommand standardCommand = new EditMeetingCommand(INDEX_FIRST, DESC_ENG);
+
+        // same values -> returns true
+        EditMeetingDescriptor copyDescriptor = new EditMeetingDescriptor(DESC_ENG);
+        EditMeetingCommand commandWithSameValues = new EditMeetingCommand(INDEX_FIRST, copyDescriptor);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new EditMeetingCommand(INDEX_SECOND, DESC_ENG)));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new EditMeetingCommand(INDEX_FIRST, DESC_CHI)));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index index = Index.fromOneBased(1);
+        EditMeetingDescriptor editMeetingDescriptor = new EditMeetingDescriptor();
+        EditMeetingCommand editMeetingCommand = new EditMeetingCommand(index, editMeetingDescriptor);
+        String expected = EditMeetingCommand.class.getCanonicalName() + "{index=" + index + ", editMeetingDescriptor="
+                + editMeetingDescriptor + "}";
+        assertEquals(expected, editMeetingCommand.toString());
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/EditMeetingDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditMeetingDescriptorTest.java
@@ -1,0 +1,65 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_CHI;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_ENG;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DESCRIPTION_CHI;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PLACE_CHI;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TIME_CHI;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TITLE_CHI;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.EditMeetingCommand.EditMeetingDescriptor;
+import seedu.address.testutil.EditMeetingDescriptorBuilder;
+
+public class EditMeetingDescriptorTest {
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        EditMeetingDescriptor descriptorWithSameValues = new EditMeetingDescriptor(DESC_ENG);
+        assertTrue(DESC_ENG.equals(descriptorWithSameValues));
+
+        // same object -> returns true
+        assertTrue(DESC_ENG.equals(DESC_ENG));
+
+        // null -> returns false
+        assertFalse(DESC_ENG.equals(null));
+
+        // different types -> returns false
+        assertFalse(DESC_ENG.equals(5));
+
+        // different values -> returns false
+        assertFalse(DESC_ENG.equals(DESC_CHI));
+
+        // different title -> returns false
+        EditMeetingDescriptor editedEng = new EditMeetingDescriptorBuilder(DESC_ENG).withTitle(VALID_TITLE_CHI).build();
+        assertFalse(DESC_ENG.equals(editedEng));
+
+        // different Time -> returns false
+        editedEng = new EditMeetingDescriptorBuilder(DESC_ENG).withTime(VALID_TIME_CHI).build();
+        assertFalse(DESC_ENG.equals(editedEng));
+
+        // different place -> returns false
+        editedEng = new EditMeetingDescriptorBuilder(DESC_ENG).withPlace(VALID_PLACE_CHI).build();
+        assertFalse(DESC_ENG.equals(editedEng));
+
+        // different description -> returns false
+        editedEng = new EditMeetingDescriptorBuilder(DESC_ENG).withDescription(VALID_DESCRIPTION_CHI).build();
+        assertFalse(DESC_ENG.equals(editedEng));
+    }
+
+    @Test
+    public void toStringMethod() {
+        EditMeetingDescriptor editMeetingDescriptor = new EditMeetingDescriptor();
+        String expected = EditMeetingDescriptor.class.getCanonicalName() + "{title="
+                + editMeetingDescriptor.getTitle().orElse(null) + ", time="
+                + editMeetingDescriptor.getTime().orElse(null) + ", place="
+                + editMeetingDescriptor.getPlace().orElse(null) + ", description="
+                + editMeetingDescriptor.getDescription().orElse(null) + "}";
+        assertEquals(expected, editMeetingDescriptor.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/DeleteMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteMeetingCommandParserTest.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.DeleteMeetingCommand;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the DeleteCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the DeleteCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class DeleteMeetingCommandParserTest {
+
+    private DeleteMeetingCommandParser parser = new DeleteMeetingCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteCommand() {
+        assertParseSuccess(parser, " -id 1", new DeleteMeetingCommand(INDEX_FIRST));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMeetingCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/EditContactCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditContactCommandParserTest.java
@@ -205,4 +205,5 @@ public class EditContactCommandParserTest {
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
+
 }

--- a/src/test/java/seedu/address/logic/parser/EditMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditMeetingCommandParserTest.java
@@ -1,0 +1,160 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.DESCRIPTION_DESC_CHI;
+import static seedu.address.logic.commands.CommandTestUtil.DESCRIPTION_DESC_ENG;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PLACE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TIME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TITLE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.PLACE_DESC_ENG;
+import static seedu.address.logic.commands.CommandTestUtil.TIME_DESC_CHI;
+import static seedu.address.logic.commands.CommandTestUtil.TIME_DESC_ENG;
+import static seedu.address.logic.commands.CommandTestUtil.TITLE_DESC_CHI;
+import static seedu.address.logic.commands.CommandTestUtil.TITLE_DESC_ENG;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DESCRIPTION_CHI;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DESCRIPTION_ENG;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PLACE_ENG;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TIME_CHI;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TIME_ENG;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TITLE_ENG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PLACE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.EditMeetingCommand;
+import seedu.address.logic.commands.EditMeetingCommand.EditMeetingDescriptor;
+import seedu.address.model.meeting.Place;
+import seedu.address.model.meeting.Time;
+import seedu.address.model.meeting.Title;
+import seedu.address.testutil.EditMeetingDescriptorBuilder;
+
+
+public class EditMeetingCommandParserTest {
+
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditMeetingCommand.MESSAGE_USAGE);
+
+    private EditMeetingCommandParser parser = new EditMeetingCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, VALID_TITLE_ENG, MESSAGE_INVALID_FORMAT);
+
+        // no field specified
+        assertParseFailure(parser, " -id 1", EditMeetingCommand.MESSAGE_NOT_EDITED);
+
+        // no index and no field specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        // negative index
+        assertParseFailure(parser, "-5" + TITLE_DESC_ENG, MESSAGE_INVALID_FORMAT);
+
+        // zero index
+        assertParseFailure(parser, "0" + TITLE_DESC_ENG, MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+
+        // invalid prefix being parsed as preamble
+        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        assertParseFailure(parser, " -id 1" + INVALID_TITLE_DESC, Title.MESSAGE_CONSTRAINTS); // invalid title
+        assertParseFailure(parser, " -id 1" + INVALID_TIME_DESC, Time.MESSAGE_CONSTRAINTS); // invalid time
+        assertParseFailure(parser, " -id 1" + INVALID_PLACE_DESC, Place.MESSAGE_CONSTRAINTS); // invalid place
+
+        // invalid time followed by valid place
+        assertParseFailure(parser, " -id 1" + INVALID_TIME_DESC + INVALID_PLACE_DESC, Time.MESSAGE_CONSTRAINTS);
+
+        // multiple invalid values, but only the first invalid value is captured
+        assertParseFailure(parser, " -id 1" + INVALID_TITLE_DESC + INVALID_TIME_DESC + VALID_PLACE_ENG
+                + VALID_DESCRIPTION_ENG, Title.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_allFieldsSpecified_success() {
+        Index targetIndex = INDEX_SECOND;
+        String userInput = " -id " + targetIndex.getOneBased() + TIME_DESC_CHI
+                + PLACE_DESC_ENG + DESCRIPTION_DESC_CHI + TITLE_DESC_ENG;
+
+        EditMeetingDescriptor descriptor = new EditMeetingDescriptorBuilder().withTitle(VALID_TITLE_ENG)
+                .withTime(VALID_TIME_CHI).withPlace(VALID_PLACE_ENG).withDescription(VALID_DESCRIPTION_CHI).build();
+        EditMeetingCommand expectedCommand = new EditMeetingCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+
+    @Test
+    public void parse_oneFieldSpecified_success() {
+        // title
+        Index targetIndex = INDEX_THIRD;
+        String userInput = " -id " + targetIndex.getOneBased() + TITLE_DESC_ENG;
+        EditMeetingDescriptor descriptor = new EditMeetingDescriptorBuilder().withTitle(VALID_TITLE_ENG).build();
+        EditMeetingCommand expectedCommand = new EditMeetingCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // time
+        userInput = " -id " + targetIndex.getOneBased() + TIME_DESC_ENG;
+        descriptor = new EditMeetingDescriptorBuilder().withTime(VALID_TIME_ENG).build();
+        expectedCommand = new EditMeetingCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // place
+        userInput = " -id " + targetIndex.getOneBased() + PLACE_DESC_ENG;
+        descriptor = new EditMeetingDescriptorBuilder().withPlace(VALID_PLACE_ENG).build();
+        expectedCommand = new EditMeetingCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // description
+        userInput = " -id " + targetIndex.getOneBased() + DESCRIPTION_DESC_ENG;
+        descriptor = new EditMeetingDescriptorBuilder().withDescription(VALID_DESCRIPTION_ENG).build();
+        expectedCommand = new EditMeetingCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_failure() {
+
+        // valid followed by invalid
+        Index targetIndex = INDEX_FIRST;
+        String userInput = " -id " + targetIndex.getOneBased() + INVALID_TIME_DESC + TIME_DESC_CHI;
+
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TIME));
+
+        // invalid followed by valid
+        userInput = " -id " + targetIndex.getOneBased() + TIME_DESC_CHI + INVALID_TIME_DESC;
+
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TIME));
+
+        // mulltiple valid fields repeated
+        userInput = " -id " + targetIndex.getOneBased() + TIME_DESC_CHI + DESCRIPTION_DESC_CHI + TITLE_DESC_CHI
+                + TIME_DESC_ENG + TITLE_DESC_ENG;
+
+        assertParseFailure(parser, userInput,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TIME, PREFIX_TITLE));
+
+        // multiple invalid values
+        userInput = " -id " + targetIndex.getOneBased() + INVALID_TITLE_DESC + INVALID_TITLE_DESC
+                + INVALID_PLACE_DESC + INVALID_PLACE_DESC;
+
+        assertParseFailure(parser, userInput,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TITLE, PREFIX_PLACE));
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/EditMeetingDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditMeetingDescriptorBuilder.java
@@ -1,0 +1,72 @@
+package seedu.address.testutil;
+
+import seedu.address.logic.commands.EditMeetingCommand.EditMeetingDescriptor;
+import seedu.address.model.meeting.Description;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.model.meeting.Place;
+import seedu.address.model.meeting.Time;
+import seedu.address.model.meeting.Title;
+
+/**
+ * A utility class to help with building EditMeetingDescriptor objects.
+ */
+public class EditMeetingDescriptorBuilder {
+
+    private EditMeetingDescriptor descriptor;
+
+    public EditMeetingDescriptorBuilder() {
+        descriptor = new EditMeetingDescriptor();
+    }
+
+    public EditMeetingDescriptorBuilder(EditMeetingDescriptor descriptor) {
+        this.descriptor = new EditMeetingDescriptor(descriptor);
+    }
+
+    /**
+     * Returns an {@code EditMeetingDescriptor} with fields containing {@code Meeting}'s details
+     */
+    public EditMeetingDescriptorBuilder(Meeting meeting) {
+        descriptor = new EditMeetingDescriptor();
+        descriptor.setTitle(meeting.getTitle());
+        descriptor.setTime(meeting.getTime());
+        descriptor.setPlace(meeting.getPlace());
+        descriptor.setDescription(meeting.getDescription());
+    }
+
+    /**
+     * Sets the {@code Title} of the {@code EditMeetingDescriptor} that we are building.
+     */
+    public EditMeetingDescriptorBuilder withTitle(String title) {
+        descriptor.setTitle(new Title(title));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Time} of the {@code EditMeetingDescriptor} that we are building.
+     */
+    public EditMeetingDescriptorBuilder withTime(String time) {
+        descriptor.setTime(new Time(time));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Place} of the {@code EditMeetingDescriptor} that we are building.
+     */
+    public EditMeetingDescriptorBuilder withPlace(String place) {
+        descriptor.setPlace(new Place(place));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Description} of the {@code EditMeetingDescriptor} that we are building.
+     */
+    public EditMeetingDescriptorBuilder withDescription(String description) {
+        descriptor.setDescription(new Description(description));
+        return this;
+    }
+
+    public EditMeetingDescriptor build() {
+        return descriptor;
+    }
+}
+

--- a/src/test/java/seedu/address/testutil/MeetingBuilder.java
+++ b/src/test/java/seedu/address/testutil/MeetingBuilder.java
@@ -38,6 +38,16 @@ public class MeetingBuilder {
     }
 
     /**
+     * Initializes the MeetingBuilder with the data of {@code meetingToCopy}.
+     */
+    public MeetingBuilder(Meeting meetingToCopy) {
+        title = meetingToCopy.getTitle();
+        time = meetingToCopy.getTime();
+        place = meetingToCopy.getPlace();
+        description = meetingToCopy.getDescription();
+    }
+
+    /**
      * Sets the {@code Title} of the {@code Meeting} that we are building.
      */
     public MeetingBuilder withTitle(String title) {


### PR DESCRIPTION
### Description
Add Tests for DeleteMeetingCommand.java and EditMeetingCommand.java, as well
as their corresponding parsers.
Refactored some contact keywords to meeting.

### Related Issue(s)
[https://github.com/AY2324S1-CS2103-W14-2/tp/issues/73](https://github.com/AY2324S1-CS2103-W14-2/tp/issues/73)

### Checklist
[Make sure to check the boxes that apply. If an item is not applicable, you can remove it.]

- [X] Unit tests have been added or updated.
- [X] Code has been tested locally and works as expected.
- [X] Documentation has been updated, if necessary.
- [X] Dependencies have been checked and updated, if necessary.
- [X] All code follows the project's coding standards and style guidelines.


### To-Do
[List any additional tasks or items that need to be completed or addressed before merging this pull request.]

### Screenshots (if applicable)
[Include any relevant screenshots to help reviewers understand the changes.]

