### PR TITLE
Implement commands to add or delete Contacts from Meetings

### DIFF
--- a/src/main/java/seedu/address/Main.java
+++ b/src/main/java/seedu/address/Main.java
@@ -7,17 +7,17 @@ import seedu.address.commons.core.LogsCenter;
 
 /**
  * The main entry point to the application.
- *
+ * <p>
  * This is a workaround for the following error when MainApp is made the
  * entry point of the application:
- *
- *     Error: JavaFX runtime components are missing, and are required to run this application
- *
+ * <p>
+ * Error: JavaFX runtime components are missing, and are required to run this application
+ * <p>
  * The reason is that MainApp extends Application. In that case, the
  * LauncherHelper will check for the javafx.graphics module to be present
  * as a named module. We don't use JavaFX via the module system so it can't
  * find the javafx.graphics module, and so the launch is aborted.
- *
+ * <p>
  * By having a separate main class (Main) that doesn't extend Application
  * to be the entry point of the application, we avoid this issue.
  */
@@ -34,7 +34,6 @@ public class Main {
         // The warning however, can be safely ignored. Thus, the following log informs
         // the user (if looking at the log output) that the said warning appearing in the log
         // can be ignored.
-
         logger.warning("The warning about Unsupported JavaFX configuration below can be ignored.");
         Application.launch(MainApp.class, args);
     }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -1,5 +1,6 @@
 package seedu.address.logic;
 
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -66,4 +67,18 @@ public class Messages {
         return builder.toString();
     }
 
+    /**
+     * Formats the {@code contacts in a meeting} for display to the user.
+     */
+    public static String formatMeetingContacts(Meeting meeting) {
+        final StringBuilder builder = new StringBuilder();
+        ArrayList<Contact> contactList = new ArrayList<>(meeting.getContacts());
+        for (Contact c : contactList) {
+            builder.append(c.getName().toString() + ", ");
+        }
+        if (builder.length() > 0) {
+            builder.deleteCharAt(builder.length() - 2);
+        }
+        return "Contacts: " + builder.toString();
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/AddContactToMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactToMeetingCommand.java
@@ -53,7 +53,7 @@ public class AddContactToMeetingCommand extends Command {
         Meeting meetingToEdit = null;
         boolean contactFound = false;
         for (Contact c : contactList) {
-            if (c.getName().toString().equals(contactName)) {
+            if (c.getNameString().equals(contactName)) {
                 contact = c;
                 contactFound = true;
                 break;
@@ -64,7 +64,7 @@ public class AddContactToMeetingCommand extends Command {
         }
         boolean meetingFound = false;
         for (Meeting m : meetingList) {
-            if (m.getTitle().toString().equals(meetingTitle)) {
+            if (m.getTitleString().equals(meetingTitle)) {
                 meetingToEdit = m;
                 meetingFound = true;
                 break;
@@ -73,7 +73,6 @@ public class AddContactToMeetingCommand extends Command {
         if (!meetingFound) {
             throw new CommandException(MESSAGE_MEETING_NOT_FOUND);
         }
-
         ArrayList<Contact> listOfContacts = new ArrayList<>(meetingToEdit.getContacts());
         listOfContacts.add(contact);
 

--- a/src/main/java/seedu/address/logic/commands/AddContactToMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactToMeetingCommand.java
@@ -1,0 +1,116 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.contact.Contact;
+import seedu.address.model.meeting.Meeting;
+
+/**
+ * Adds a contact to a meeting.
+ */
+public class AddContactToMeetingCommand extends Command {
+    public static final String COMMAND_WORD = "add contact to meeting";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Adds the participants to the meeting identified "
+            + "by the name of the contact. "
+            + "Parameters: " + PREFIX_NAME
+            + " [CONTACT NAME] "
+            + PREFIX_TITLE + " [MEETING NAME]\n"
+            + "Example: " + COMMAND_WORD + PREFIX_NAME
+            + " Sarah Woo " + PREFIX_TITLE + " Project Discussion";
+
+    public static final String MESSAGE_ADD_CONTACT_SUCCESS = "Added contact '%s' to Meeting '%s' \n%s";
+    public static final String MESSAGE_CONTACT_NOT_FOUND = "The person specified is not created";
+    public static final String MESSAGE_MEETING_NOT_FOUND = "The meeting specified is not created";
+
+    private final String meetingTitle;
+    private final String contactName;
+
+    /**
+     * @param meetingTitle String of the meeting which the contact is added to
+     * @param contactName  String of the contact to be added in the meeting
+     */
+    public AddContactToMeetingCommand(String meetingTitle, String contactName) {
+        requireAllNonNull(meetingTitle, contactName);
+
+        this.meetingTitle = meetingTitle;
+        this.contactName = contactName;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        List<Meeting> meetingList = model.getFilteredMeetingList();
+        List<Contact> contactList = model.getFilteredContactList();
+        Contact contact = null;
+        Meeting meetingToEdit = null;
+        boolean contactFound = false;
+        for (Contact c : contactList) {
+            if (c.getName().toString().equals(contactName)) {
+                contact = c;
+                contactFound = true;
+                break;
+            }
+        }
+        if (!contactFound) {
+            throw new CommandException(MESSAGE_CONTACT_NOT_FOUND);
+        }
+        boolean meetingFound = false;
+        for (Meeting m : meetingList) {
+            if (m.getTitle().toString().equals(meetingTitle)) {
+                meetingToEdit = m;
+                meetingFound = true;
+                break;
+            }
+        }
+        if (!meetingFound) {
+            throw new CommandException(MESSAGE_MEETING_NOT_FOUND);
+        }
+
+        ArrayList<Contact> listOfContacts = new ArrayList<>(meetingToEdit.getContacts());
+        listOfContacts.add(contact);
+
+        Meeting editedMeeting = new Meeting(
+                meetingToEdit.getTitle(), meetingToEdit.getTime(), meetingToEdit.getPlace(),
+                meetingToEdit.getDescription(), meetingToEdit.getNotes(), listOfContacts);
+
+        model.setMeeting(meetingToEdit, editedMeeting);
+        model.updateFilteredMeetingList(Model.PREDICATE_SHOW_ALL_MEETINGS);
+
+        return new CommandResult(String.format(MESSAGE_ADD_CONTACT_SUCCESS,
+                contactName, meetingTitle, Messages.formatMeetingContacts(editedMeeting)));
+    }
+
+    public String getContactName() {
+        return contactName;
+    }
+
+    public String getMeetingTitle() {
+        return meetingTitle;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddContactToMeetingCommand)) {
+            return false;
+        }
+
+        // state check
+        AddContactToMeetingCommand e = (AddContactToMeetingCommand) other;
+        return this.meetingTitle.equals(e.getMeetingTitle()) && this.contactName.equals(e.getContactName());
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/AddContactToMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactToMeetingCommand.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 import java.util.ArrayList;
 import java.util.List;
 
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.contact.Contact;
@@ -20,15 +19,15 @@ public class AddContactToMeetingCommand extends Command {
     public static final String COMMAND_WORD = "add contact to meeting";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Adds the participants to the meeting identified "
-            + "by the name of the contact. "
-            + "Parameters: " + PREFIX_NAME
-            + " [CONTACT NAME] "
-            + PREFIX_TITLE + " [MEETING NAME]\n"
-            + "Example: " + COMMAND_WORD + PREFIX_NAME
-            + " Sarah Woo " + PREFIX_TITLE + " Project Discussion";
+        + ": Adds the participants to the meeting identified "
+        + "by the name of the contact. "
+        + "Parameters: " + PREFIX_NAME
+        + " [CONTACT NAME] "
+        + PREFIX_TITLE + " [MEETING NAME]\n"
+        + "Example: " + COMMAND_WORD + PREFIX_NAME
+        + " Sarah Woo " + PREFIX_TITLE + " Project Discussion";
 
-    public static final String MESSAGE_ADD_CONTACT_SUCCESS = "Added contact '%s' to Meeting '%s' \n%s";
+    public static final String MESSAGE_ADD_CONTACT_SUCCESS = "Added contact '%s' to Meeting '%s'";
     public static final String MESSAGE_CONTACT_NOT_FOUND = "The person specified is not created";
     public static final String MESSAGE_MEETING_NOT_FOUND = "The meeting specified is not created";
 
@@ -79,14 +78,14 @@ public class AddContactToMeetingCommand extends Command {
         listOfContacts.add(contact);
 
         Meeting editedMeeting = new Meeting(
-                meetingToEdit.getTitle(), meetingToEdit.getTime(), meetingToEdit.getPlace(),
-                meetingToEdit.getDescription(), meetingToEdit.getNotes(), listOfContacts);
+            meetingToEdit.getTitle(), meetingToEdit.getTime(), meetingToEdit.getPlace(),
+            meetingToEdit.getDescription(), meetingToEdit.getNotes(), listOfContacts);
 
         model.setMeeting(meetingToEdit, editedMeeting);
         model.updateFilteredMeetingList(Model.PREDICATE_SHOW_ALL_MEETINGS);
 
         return new CommandResult(String.format(MESSAGE_ADD_CONTACT_SUCCESS,
-                contactName, meetingTitle, Messages.formatMeetingContacts(editedMeeting)));
+            contactName, meetingTitle));
     }
 
     public String getContactName() {

--- a/src/main/java/seedu/address/logic/commands/AddMeetingNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMeetingNoteCommand.java
@@ -62,7 +62,7 @@ public class AddMeetingNoteCommand extends Command {
 
         Meeting editedMeeting = new Meeting(
                 meetingToEdit.getTitle(), meetingToEdit.getTime(), meetingToEdit.getPlace(),
-                meetingToEdit.getDescription(), mutableNotesList);
+                meetingToEdit.getDescription(), mutableNotesList, meetingToEdit.getContacts());
 
         model.setMeeting(meetingToEdit, editedMeeting);
         model.updateFilteredMeetingList(Model.PREDICATE_SHOW_ALL_MEETINGS);

--- a/src/main/java/seedu/address/logic/commands/DeleteContactFromMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteContactFromMeetingCommand.java
@@ -53,7 +53,7 @@ public class DeleteContactFromMeetingCommand extends Command {
         Meeting meetingToEdit = null;
         boolean meetingFound = false;
         for (Meeting m : meetingList) {
-            if (m.getTitle().toString().equals(meetingTitle)) {
+            if (m.getTitleString().equals(meetingTitle)) {
                 meetingToEdit = m;
                 meetingFound = true;
                 break;
@@ -65,7 +65,7 @@ public class DeleteContactFromMeetingCommand extends Command {
         ArrayList<Contact> listOfContacts = new ArrayList<>(meetingToEdit.getContacts());
         boolean contactFound = false;
         for (Contact c : listOfContacts) {
-            if (c.getName().toString().equals(contactName)) {
+            if (c.getNameString().equals(contactName)) {
                 contact = c;
                 contactFound = true;
             }

--- a/src/main/java/seedu/address/logic/commands/DeleteContactFromMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteContactFromMeetingCommand.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 import java.util.ArrayList;
 import java.util.List;
 
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.contact.Contact;
@@ -20,15 +19,15 @@ public class DeleteContactFromMeetingCommand extends Command {
     public static final String COMMAND_WORD = "delete contact from meeting";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Removes the participants to the meeting identified "
-            + "by the name of the contact. "
-            + "Parameters: " + PREFIX_NAME
-            + " [CONTACT NAME] "
-            + PREFIX_TITLE + " [MEETING NAME]\n"
-            + "Example: " + COMMAND_WORD + PREFIX_NAME
-            + " Sarah Woo " + PREFIX_TITLE + " Project Discussion";
+        + ": Removes the participants to the meeting identified "
+        + "by the name of the contact. "
+        + "Parameters: " + PREFIX_NAME
+        + " [CONTACT NAME] "
+        + PREFIX_TITLE + " [MEETING NAME]\n"
+        + "Example: " + COMMAND_WORD + PREFIX_NAME
+        + " Sarah Woo " + PREFIX_TITLE + " Project Discussion";
 
-    public static final String MESSAGE_DELETE_CONTACT_SUCCESS = "Removed contact '%s' from Meeting '%s' \n%s";
+    public static final String MESSAGE_DELETE_CONTACT_SUCCESS = "Removed contact '%s' from Meeting '%s'";
     public static final String MESSAGE_CONTACT_NOT_FOUND = "The person specified is not created";
     public static final String MESSAGE_MEETING_NOT_FOUND = "The meeting specified is not created";
 
@@ -74,17 +73,18 @@ public class DeleteContactFromMeetingCommand extends Command {
         if (!contactFound) {
             throw new CommandException(MESSAGE_CONTACT_NOT_FOUND);
         }
+        assert listOfContacts.contains(contact);
         listOfContacts.remove(contact);
 
         Meeting editedMeeting = new Meeting(
-                meetingToEdit.getTitle(), meetingToEdit.getTime(), meetingToEdit.getPlace(),
-                meetingToEdit.getDescription(), meetingToEdit.getNotes(), listOfContacts);
+            meetingToEdit.getTitle(), meetingToEdit.getTime(), meetingToEdit.getPlace(),
+            meetingToEdit.getDescription(), meetingToEdit.getNotes(), listOfContacts);
 
         model.setMeeting(meetingToEdit, editedMeeting);
         model.updateFilteredMeetingList(Model.PREDICATE_SHOW_ALL_MEETINGS);
 
         return new CommandResult(String.format(MESSAGE_DELETE_CONTACT_SUCCESS,
-                contactName, meetingTitle, Messages.formatMeetingContacts(editedMeeting)));
+            contactName, meetingTitle));
     }
 
     public String getContactName() {

--- a/src/main/java/seedu/address/logic/commands/DeleteContactFromMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteContactFromMeetingCommand.java
@@ -1,0 +1,114 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.contact.Contact;
+import seedu.address.model.meeting.Meeting;
+
+/**
+ * Deletes a contact from a meeting identified using it's name
+ */
+public class DeleteContactFromMeetingCommand extends Command {
+    public static final String COMMAND_WORD = "delete contact from meeting";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Removes the participants to the meeting identified "
+            + "by the name of the contact. "
+            + "Parameters: " + PREFIX_NAME
+            + " [CONTACT NAME] "
+            + PREFIX_TITLE + " [MEETING NAME]\n"
+            + "Example: " + COMMAND_WORD + PREFIX_NAME
+            + " Sarah Woo " + PREFIX_TITLE + " Project Discussion";
+
+    public static final String MESSAGE_DELETE_CONTACT_SUCCESS = "Removed contact '%s' from Meeting '%s' \n%s";
+    public static final String MESSAGE_CONTACT_NOT_FOUND = "The person specified is not created";
+    public static final String MESSAGE_MEETING_NOT_FOUND = "The meeting specified is not created";
+
+    private final String meetingTitle;
+    private final String contactName;
+
+    /**
+     * @param meetingTitle String of the meeting which the contact is added to
+     * @param contactName  String of the contact to be added in the meeting
+     */
+    public DeleteContactFromMeetingCommand(String meetingTitle, String contactName) {
+        requireAllNonNull(meetingTitle, contactName);
+
+        this.meetingTitle = meetingTitle;
+        this.contactName = contactName;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        List<Meeting> meetingList = model.getFilteredMeetingList();
+        List<Contact> contactList = model.getFilteredContactList();
+        Contact contact = null;
+        Meeting meetingToEdit = null;
+        boolean meetingFound = false;
+        for (Meeting m : meetingList) {
+            if (m.getTitle().toString().equals(meetingTitle)) {
+                meetingToEdit = m;
+                meetingFound = true;
+                break;
+            }
+        }
+        if (!meetingFound) {
+            throw new CommandException(MESSAGE_MEETING_NOT_FOUND);
+        }
+        ArrayList<Contact> listOfContacts = new ArrayList<>(meetingToEdit.getContacts());
+        boolean contactFound = false;
+        for (Contact c : listOfContacts) {
+            if (c.getName().toString().equals(contactName)) {
+                contact = c;
+                contactFound = true;
+            }
+        }
+        if (!contactFound) {
+            throw new CommandException(MESSAGE_CONTACT_NOT_FOUND);
+        }
+        listOfContacts.remove(contact);
+
+        Meeting editedMeeting = new Meeting(
+                meetingToEdit.getTitle(), meetingToEdit.getTime(), meetingToEdit.getPlace(),
+                meetingToEdit.getDescription(), meetingToEdit.getNotes(), listOfContacts);
+
+        model.setMeeting(meetingToEdit, editedMeeting);
+        model.updateFilteredMeetingList(Model.PREDICATE_SHOW_ALL_MEETINGS);
+
+        return new CommandResult(String.format(MESSAGE_DELETE_CONTACT_SUCCESS,
+                contactName, meetingTitle, Messages.formatMeetingContacts(editedMeeting)));
+    }
+
+    public String getContactName() {
+        return contactName;
+    }
+
+    public String getMeetingTitle() {
+        return meetingTitle;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteContactFromMeetingCommand)) {
+            return false;
+        }
+
+        // state check
+        DeleteContactFromMeetingCommand e = (DeleteContactFromMeetingCommand) other;
+        return this.meetingTitle.equals(e.getMeetingTitle()) && this.contactName.equals(e.getContactName());
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_MEETINGS;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -20,6 +21,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.contact.Contact;
 import seedu.address.model.meeting.Description;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.meeting.Place;
@@ -84,7 +86,7 @@ public class EditMeetingCommand extends Command {
         model.setMeeting(meetingToEdit, editedMeeting);
         model.updateFilteredMeetingList(PREDICATE_SHOW_ALL_MEETINGS);
         return new CommandResult(String.format(MESSAGE_EDIT_MEETING_SUCCESS,
-            Messages.formatMeeting(editedMeeting)));
+                Messages.formatMeeting(editedMeeting)));
     }
 
     /**
@@ -99,8 +101,8 @@ public class EditMeetingCommand extends Command {
         Place updatedPlace = editMeetingDescriptor.getPlace().orElse(meetingToEdit.getPlace());
         Description updatedDescription = editMeetingDescriptor.getDescription().orElse(meetingToEdit.getDescription());
         Set<Note> updatedNotes = editMeetingDescriptor.getNotes().orElse(meetingToEdit.getNotes());
-
-        return new Meeting(updatedTitle, updatedTime, updatedPlace, updatedDescription, updatedNotes);
+        ArrayList<Contact> updatedContacts = editMeetingDescriptor.getContacts().orElse(meetingToEdit.getContacts());
+        return new Meeting(updatedTitle, updatedTime, updatedPlace, updatedDescription, updatedNotes, updatedContacts);
     }
 
     @Override
@@ -138,6 +140,7 @@ public class EditMeetingCommand extends Command {
         private Description description;
 
         private Set<Note> notes;
+        private ArrayList<Contact> contacts;
 
         public EditMeetingDescriptor() {
         }
@@ -151,6 +154,7 @@ public class EditMeetingCommand extends Command {
             setPlace(toCopy.place);
             setDescription(toCopy.description);
             setNotes(toCopy.notes);
+            setContacts(toCopy.contacts);
         }
 
         /**
@@ -191,6 +195,7 @@ public class EditMeetingCommand extends Command {
         public Optional<Description> getDescription() {
             return Optional.ofNullable(description);
         }
+
         /**
          * Sets {@code notes} to this object's {@code notes}.
          * A defensive copy of {@code notes} is used internally.
@@ -206,6 +211,16 @@ public class EditMeetingCommand extends Command {
          */
         public Optional<Set<Note>> getNotes() {
             return (notes != null) ? Optional.of(Collections.unmodifiableSet(notes)) : Optional.empty();
+        }
+
+        public void setContacts(ArrayList<Contact> contacts) {
+            this.contacts = (contacts != null) ? new ArrayList<>(contacts) : null;
+        }
+
+        public Optional<ArrayList<Contact>> getContacts() {
+            return (contacts != null)
+                    ? Optional.of(new ArrayList<Contact>(Collections.unmodifiableList(contacts)))
+                    : Optional.empty();
         }
 
         @Override

--- a/src/main/java/seedu/address/logic/commands/ViewMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewMeetingCommand.java
@@ -21,9 +21,9 @@ public class ViewMeetingCommand extends Command {
     public static final String COMMAND_WORD = "view meeting";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Shows the details of the meeting identified by its id in the displayed meeting list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " -id1";
+        + ": Shows the details of the meeting identified by its id in the displayed meeting list.\n"
+        + "Parameters: INDEX (must be a positive integer)\n"
+        + "Example: " + COMMAND_WORD + " -id1";
 
     public static final String MESSAGE_VIEW_MEETING_SUCCESS = "Showing Meeting: %1$s";
 
@@ -54,9 +54,8 @@ public class ViewMeetingCommand extends Command {
         }
 
         //todo: change display to note when it is implemented
-        return new CommandResult(String.format(MESSAGE_VIEW_MEETING_SUCCESS + "\n"
-                        + Messages.formatMeetingContacts(meetingToDisplay),
-                Messages.formatMeeting(meetingToDisplay)), meetingToDisplay, sb.toString());
+        return new CommandResult(String.format(MESSAGE_VIEW_MEETING_SUCCESS,
+            Messages.formatMeeting(meetingToDisplay)), meetingToDisplay, sb.toString());
 
     }
 
@@ -78,7 +77,7 @@ public class ViewMeetingCommand extends Command {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("targetIndex", targetIndex)
-                .toString();
+            .add("targetIndex", targetIndex)
+            .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewMeetingCommand.java
@@ -54,8 +54,9 @@ public class ViewMeetingCommand extends Command {
         }
 
         //todo: change display to note when it is implemented
-        return new CommandResult(String.format(MESSAGE_VIEW_MEETING_SUCCESS, Messages.formatMeeting(meetingToDisplay)),
-                meetingToDisplay, sb.toString());
+        return new CommandResult(String.format(MESSAGE_VIEW_MEETING_SUCCESS + "\n"
+                        + Messages.formatMeetingContacts(meetingToDisplay),
+                Messages.formatMeeting(meetingToDisplay)), meetingToDisplay, sb.toString());
 
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddContactToMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddContactToMeetingCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
+
+import seedu.address.logic.commands.AddContactToMeetingCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new AddContactToMeetingCommand object
+ */
+public class AddContactToMeetingCommandParser implements Parser<AddContactToMeetingCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code AddContactToMeetingCommand}
+     * and returns a {@code AddContactToMeetingCommand} object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddContactToMeetingCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TITLE);
+
+        String contactName = argMultimap.getValue(PREFIX_NAME).orElse("");
+        String meetingTitle = argMultimap.getValue(PREFIX_TITLE).orElse("");
+
+        return new AddContactToMeetingCommand(meetingTitle, contactName);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PLACE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -26,12 +27,13 @@ public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the AddMeetingCommand
      * and returns an AddMeetingCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddMeetingCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_TIME, PREFIX_PLACE,
-                PREFIX_DESCRIPTION);
+                        PREFIX_DESCRIPTION);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_TITLE) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingCommand.MESSAGE_USAGE));
@@ -44,7 +46,7 @@ public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
         Description description =
                 ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).orElse("No description"));
         Set<Note> noteList = ParserUtil.parseNotes(argMultimap.getAllValues(PREFIX_NOTE_MEETING));
-        Meeting meeting = new Meeting(title, time, place, description, noteList);
+        Meeting meeting = new Meeting(title, time, place, description, noteList, new ArrayList<>());
         return new AddMeetingCommand(meeting);
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -9,12 +9,14 @@ import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddContactCommand;
+import seedu.address.logic.commands.AddContactToMeetingCommand;
 import seedu.address.logic.commands.AddMeetingCommand;
 import seedu.address.logic.commands.AddMeetingNoteCommand;
 import seedu.address.logic.commands.AddNoteCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteContactCommand;
+import seedu.address.logic.commands.DeleteContactFromMeetingCommand;
 import seedu.address.logic.commands.DeleteMeetingCommand;
 import seedu.address.logic.commands.EditContactCommand;
 import seedu.address.logic.commands.EditMeetingCommand;
@@ -84,6 +86,12 @@ public class AddressBookParser {
 
         case DeleteMeetingCommand.COMMAND_WORD:
             return new DeleteMeetingCommandParser().parse(arguments);
+
+        case AddContactToMeetingCommand.COMMAND_WORD:
+            return new AddContactToMeetingCommandParser().parse(arguments);
+
+        case DeleteContactFromMeetingCommand.COMMAND_WORD:
+            return new DeleteContactFromMeetingCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -60,7 +60,6 @@ public class AddressBookParser {
         // log messages such as the one below.
         // Lower level log messages are used sparingly to minimize noise in the code.
         logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
-
         switch (commandWord) {
 
         case AddContactCommand.COMMAND_WORD:

--- a/src/main/java/seedu/address/logic/parser/DeleteContactFromMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteContactFromMeetingCommandParser.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
+
+import seedu.address.logic.commands.DeleteContactFromMeetingCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteContactFromMeetingCommandParser object
+ */
+public class DeleteContactFromMeetingCommandParser implements Parser<DeleteContactFromMeetingCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code DeleteContactFromMeetingCommand}
+     * and returns a {@code DeleteContactFromMeetingCommand} object for execution.
+     *
+     * @throws seedu.address.logic.parser.exceptions.ParseException if the user input does not conform to
+     *                                                              the expected format
+     */
+    public DeleteContactFromMeetingCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TITLE);
+
+        String contactName = argMultimap.getValue(PREFIX_NAME).orElse("");
+        String meetingTitle = argMultimap.getValue(PREFIX_TITLE).orElse("");
+
+        return new DeleteContactFromMeetingCommand(meetingTitle, contactName);
+    }
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -29,12 +29,14 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Note that non-static init blocks are not recommended to use. There are other ways to avoid duplication
      *   among constructors.
      */
+
     {
         contacts = new UniqueContactList();
         meetings = new MeetingList();
     }
 
-    public AddressBook() {}
+    public AddressBook() {
+    }
 
     /**
      * Creates an AddressBook using the Contacts in the {@code toBeCopied}

--- a/src/main/java/seedu/address/model/contact/Contact.java
+++ b/src/main/java/seedu/address/model/contact/Contact.java
@@ -44,6 +44,10 @@ public class Contact {
         return name;
     }
 
+    public String getNameString() {
+        return name.toString();
+    }
+
     public Phone getPhone() {
         return phone;
     }
@@ -78,7 +82,7 @@ public class Contact {
         }
 
         return otherContact != null
-                && otherContact.getName().equals(getName());
+            && otherContact.getName().equals(getName());
     }
 
     /**
@@ -98,11 +102,11 @@ public class Contact {
 
         Contact otherContact = (Contact) other;
         return name.equals(otherContact.name)
-                && phone.equals(otherContact.phone)
-                && email.equals(otherContact.email)
-                && address.equals(otherContact.address)
-                && tags.equals(otherContact.tags)
-                && notes.equals(otherContact.notes);
+            && phone.equals(otherContact.phone)
+            && email.equals(otherContact.email)
+            && address.equals(otherContact.address)
+            && tags.equals(otherContact.tags)
+            && notes.equals(otherContact.notes);
     }
 
     @Override
@@ -114,13 +118,13 @@ public class Contact {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("name", name)
-                .add("phone", phone)
-                .add("email", email)
-                .add("address", address)
-                .add("tags", tags)
-                .add("notes", notes)
-                .toString();
+            .add("name", name)
+            .add("phone", phone)
+            .add("email", email)
+            .add("address", address)
+            .add("tags", tags)
+            .add("notes", notes)
+            .toString();
     }
 
 }

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -26,7 +26,7 @@ public class Meeting {
 
     private Description description;
     private Set<Note> notes = new HashSet<>();
-    private ArrayList<Contact> participants = new ArrayList<>();
+    private ArrayList<Contact> contacts = new ArrayList<>();
 
     /**
      * Every field must be present and not null.
@@ -39,11 +39,15 @@ public class Meeting {
         this.place = place;
         this.description = description;
         this.notes.addAll(notes);
-        this.participants.addAll(contacts);
+        this.contacts.addAll(contacts);
     }
 
     public Title getTitle() {
         return title;
+    }
+
+    public String getTitleString() {
+        return title.toString();
     }
 
     public Time getTime() {
@@ -63,19 +67,19 @@ public class Meeting {
     }
 
     public ArrayList<Contact> getContacts() {
-        return new ArrayList<>(Collections.unmodifiableList(participants));
+        return new ArrayList<>(Collections.unmodifiableList(contacts));
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("title", title)
-                .add("time", time)
-                .add("place", place)
-                .add("description", description)
-                .add("notes", notes)
-                .add("contacts", participants)
-                .toString();
+            .add("title", title)
+            .add("time", time)
+            .add("place", place)
+            .add("description", description)
+            .add("notes", notes)
+            .add("contacts", contacts)
+            .toString();
     }
 
     @Override
@@ -91,11 +95,11 @@ public class Meeting {
 
         Meeting otherMeeting = (Meeting) other;
         return title.equals(otherMeeting.title)
-                && time.equals(otherMeeting.time)
-                && place.equals(otherMeeting.place)
-                && description.equals(otherMeeting.description)
-                && notes.equals(otherMeeting.notes)
-                && participants.equals(otherMeeting.participants);
+            && time.equals(otherMeeting.time)
+            && place.equals(otherMeeting.place)
+            && description.equals(otherMeeting.description)
+            && notes.equals(otherMeeting.notes)
+            && contacts.equals(otherMeeting.contacts);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -2,12 +2,14 @@ package seedu.address.model.meeting;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.contact.Contact;
 import seedu.address.model.note.Note;
 
 /**
@@ -24,17 +26,20 @@ public class Meeting {
 
     private Description description;
     private Set<Note> notes = new HashSet<>();
+    private ArrayList<Contact> participants = new ArrayList<>();
 
     /**
      * Every field must be present and not null.
      */
-    public Meeting(Title title, Time time, Place place, Description description, Set<Note> notes) {
-        requireAllNonNull(title, time, place, description, notes);
+    public Meeting(Title title, Time time, Place place, Description description,
+                   Set<Note> notes, ArrayList<Contact> contacts) {
+        requireAllNonNull(title, time, place, description, notes, contacts);
         this.title = title;
         this.time = time;
         this.place = place;
         this.description = description;
         this.notes.addAll(notes);
+        this.participants.addAll(contacts);
     }
 
     public Title getTitle() {
@@ -57,6 +62,10 @@ public class Meeting {
         return Collections.unmodifiableSet(notes);
     }
 
+    public ArrayList<Contact> getContacts() {
+        return new ArrayList<>(Collections.unmodifiableList(participants));
+    }
+
     @Override
     public String toString() {
         return new ToStringBuilder(this)
@@ -65,6 +74,7 @@ public class Meeting {
                 .add("place", place)
                 .add("description", description)
                 .add("notes", notes)
+                .add("contacts", participants)
                 .toString();
     }
 
@@ -84,7 +94,8 @@ public class Meeting {
                 && time.equals(otherMeeting.time)
                 && place.equals(otherMeeting.place)
                 && description.equals(otherMeeting.description)
-                && notes.equals(otherMeeting.notes);
+                && notes.equals(otherMeeting.notes)
+                && participants.equals(otherMeeting.participants);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -20,13 +20,14 @@ import seedu.address.model.tag.Tag;
 public class SampleDataUtil {
 
     private static final Set<Note> EMPTY_NOTE = getNoteSet("");
+
     public static Contact[] getSampleContacts() {
-        return new Contact[] {
+        return new Contact[]{
             new Contact(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"), getTagSet("friends"), EMPTY_NOTE),
             new Contact(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                    getTagSet("colleagues", "friends"), EMPTY_NOTE),
+                getTagSet("colleagues", "friends"), EMPTY_NOTE),
             new Contact(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), getTagSet("neighbours"), EMPTY_NOTE),
             new Contact(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
@@ -51,8 +52,8 @@ public class SampleDataUtil {
      */
     public static Set<Tag> getTagSet(String... strings) {
         return Arrays.stream(strings)
-                .map(Tag::new)
-                .collect(Collectors.toSet());
+            .map(Tag::new)
+            .collect(Collectors.toSet());
     }
 
     /**
@@ -60,7 +61,7 @@ public class SampleDataUtil {
      */
     public static Set<Note> getNoteSet(String... strings) {
         return Arrays.stream(strings)
-                .map(Note::new)
-                .collect(Collectors.toSet());
+            .map(Note::new)
+            .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedMeeting.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedMeeting.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.contact.Contact;
 import seedu.address.model.meeting.Description;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.meeting.Place;
@@ -29,20 +30,25 @@ class JsonAdaptedMeeting {
     private final String place;
     private final String description;
     private final List<JsonAdaptedNote> notes = new ArrayList<>();
+    private final List<JsonAdaptedContact> contacts = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedMeeting} with the given meeting details.
      */
     @JsonCreator
     public JsonAdaptedMeeting(@JsonProperty("title") String title, @JsonProperty("time") String time,
-            @JsonProperty("place") String place, @JsonProperty("description") String description,
-                              @JsonProperty("notes") List<JsonAdaptedNote> notes) {
+                              @JsonProperty("place") String place, @JsonProperty("description") String description,
+                              @JsonProperty("notes") List<JsonAdaptedNote> notes,
+                              @JsonProperty("contacts") List<JsonAdaptedContact> contacts) {
         this.title = title;
         this.time = time;
         this.place = place;
         this.description = description;
         if (notes != null) {
             this.notes.addAll(notes);
+        }
+        if (contacts != null) {
+            this.contacts.addAll(contacts);
         }
     }
 
@@ -56,7 +62,11 @@ class JsonAdaptedMeeting {
         description = source.getDescription().fullDescription;
         notes.addAll(source.getNotes().stream()
                 .map(JsonAdaptedNote::new)
-                .collect(Collectors.toList()));;
+                .collect(Collectors.toList()));
+        ;
+        contacts.addAll(source.getContacts().stream()
+                .map(JsonAdaptedContact::new)
+                .collect(Collectors.toList()));
     }
 
     /**
@@ -66,8 +76,12 @@ class JsonAdaptedMeeting {
      */
     public Meeting toModelType() throws IllegalValueException {
         final List<Note> meetingNotes = new ArrayList<>();
+        final List<Contact> participants = new ArrayList<>();
         for (JsonAdaptedNote note : notes) {
             meetingNotes.add(note.toModelType());
+        }
+        for (JsonAdaptedContact c : contacts) {
+            participants.add(c.toModelType());
         }
 
         if (title == null) {
@@ -97,13 +111,14 @@ class JsonAdaptedMeeting {
 
         if (description == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
-                Description.class.getSimpleName()));
+                    Description.class.getSimpleName()));
         }
         final Description modelDescription = new Description(description);
 
         final Set<Note> modelNotes = new HashSet<>(meetingNotes);
+        final ArrayList<Contact> modelContacts = new ArrayList<>(participants);
 
-        return new Meeting(modelTitle, modelTime, modelPlace, modelDescription, modelNotes);
+        return new Meeting(modelTitle, modelTime, modelPlace, modelDescription, modelNotes, modelContacts);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedMeeting.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedMeeting.java
@@ -61,12 +61,12 @@ class JsonAdaptedMeeting {
         place = source.getPlace().fullPlace;
         description = source.getDescription().fullDescription;
         notes.addAll(source.getNotes().stream()
-                .map(JsonAdaptedNote::new)
-                .collect(Collectors.toList()));
+            .map(JsonAdaptedNote::new)
+            .collect(Collectors.toList()));
         ;
         contacts.addAll(source.getContacts().stream()
-                .map(JsonAdaptedContact::new)
-                .collect(Collectors.toList()));
+            .map(JsonAdaptedContact::new)
+            .collect(Collectors.toList()));
     }
 
     /**
@@ -76,12 +76,12 @@ class JsonAdaptedMeeting {
      */
     public Meeting toModelType() throws IllegalValueException {
         final List<Note> meetingNotes = new ArrayList<>();
-        final List<Contact> participants = new ArrayList<>();
+        final List<Contact> contactList = new ArrayList<>();
         for (JsonAdaptedNote note : notes) {
             meetingNotes.add(note.toModelType());
         }
         for (JsonAdaptedContact c : contacts) {
-            participants.add(c.toModelType());
+            contactList.add(c.toModelType());
         }
 
         if (title == null) {
@@ -111,12 +111,12 @@ class JsonAdaptedMeeting {
 
         if (description == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
-                    Description.class.getSimpleName()));
+                Description.class.getSimpleName()));
         }
         final Description modelDescription = new Description(description);
 
         final Set<Note> modelNotes = new HashSet<>(meetingNotes);
-        final ArrayList<Contact> modelContacts = new ArrayList<>(participants);
+        final ArrayList<Contact> modelContacts = new ArrayList<>(contactList);
 
         return new Meeting(modelTitle, modelTime, modelPlace, modelDescription, modelNotes, modelContacts);
     }

--- a/src/main/java/seedu/address/ui/MeetingDetailPanel.java
+++ b/src/main/java/seedu/address/ui/MeetingDetailPanel.java
@@ -3,6 +3,7 @@ package seedu.address.ui;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
+import seedu.address.logic.Messages;
 import seedu.address.model.meeting.Meeting;
 
 /**
@@ -24,6 +25,9 @@ public class MeetingDetailPanel extends UiPart<Region> {
     @FXML
     private Label description;
 
+    @FXML
+    private Label contacts;
+
     public MeetingDetailPanel() {
         super(FXML);
     }
@@ -33,6 +37,7 @@ public class MeetingDetailPanel extends UiPart<Region> {
         time.setText(meeting.getTime().toString());
         place.setText(meeting.getPlace().toString());
         description.setText(meeting.getDescription().toString());
+        contacts.setText(Messages.formatMeetingContacts(meeting));
     }
 
 }

--- a/src/main/resources/view/MeetingDetailPanel.fxml
+++ b/src/main/resources/view/MeetingDetailPanel.fxml
@@ -5,26 +5,32 @@
 <?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox id="meetingDetailPane" fx:id="meetingDetailPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<VBox id="meetingDetailPane" fx:id="meetingDetailPane" xmlns="http://javafx.com/javafx/17"
+      xmlns:fx="http://javafx.com/fxml/1">
     <padding>
-        <Insets top="10" right="10" bottom="10" left="10" />
+        <Insets top="10" right="10" bottom="10" left="10"/>
     </padding>
 
     <!-- Name -->
-    <Label fx:id="title" text="\$first" styleClass="cell_big_label" />
+    <Label fx:id="title" text="\$first" styleClass="cell_big_label" style="-fx-text-fill: white;"/>
 
     <!-- Time -->
     <VBox spacing="1">
-        <Label fx:id="time" styleClass="cell_small_label" text="\$time" />
+        <Label fx:id="time" styleClass="cell_small_label" text="\$time" style="-fx-text-fill: white;"/>
     </VBox>
 
     <!-- Place -->
     <VBox spacing="1">
-        <Label fx:id="place" styleClass="cell_small_label" text="\$place" />
+        <Label fx:id="place" styleClass="cell_small_label" text="\$place" style="-fx-text-fill: white;"/>
     </VBox>
 
     <!-- Description -->
     <VBox spacing="1">
-        <Label fx:id="description" styleClass="cell_small_label" text="\$description" />
+        <Label fx:id="description" styleClass="cell_small_label" text="\$description" style="-fx-text-fill: white;"/>
+    </VBox>
+
+    <!-- Contacts -->
+    <VBox spacing="1">
+        <Label fx:id="contacts" styleClass="cell_small_label" text="\$contacts" style="-fx-text-fill: white;"/>
     </VBox>
 </VBox>

--- a/src/test/java/seedu/address/logic/commands/AddContactToMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddContactToMeetingCommandTest.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.contact.Contact;
+import seedu.address.model.meeting.Meeting;
+
+class AddContactToMeetingCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    void execute_validInputs_success() throws CommandException {
+        Contact validContact = model.getFilteredContactList().get(INDEX_FIRST.getZeroBased());
+        Meeting validMeeting = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
+        AddContactToMeetingCommand command = new AddContactToMeetingCommand(validMeeting.getTitle().toString(),
+            validContact.getName().toString());
+        CommandResult expectedCommandResult = new CommandResult(String.format("Added contact '%s' to Meeting '%s'",
+            validContact.getName().toString(), validMeeting.getTitle().toString()));
+        CommandResult result = command.execute(model);
+        assertEquals(expectedCommandResult, result);
+
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/AddContactToMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddContactToMeetingCommandTest.java
@@ -21,10 +21,10 @@ class AddContactToMeetingCommandTest {
     void execute_validInputs_success() throws CommandException {
         Contact validContact = model.getFilteredContactList().get(INDEX_FIRST.getZeroBased());
         Meeting validMeeting = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
-        AddContactToMeetingCommand command = new AddContactToMeetingCommand(validMeeting.getTitle().toString(),
-            validContact.getName().toString());
+        AddContactToMeetingCommand command = new AddContactToMeetingCommand(validMeeting.getTitleString(),
+            validContact.getNameString());
         CommandResult expectedCommandResult = new CommandResult(String.format("Added contact '%s' to Meeting '%s'",
-            validContact.getName().toString(), validMeeting.getTitle().toString()));
+            validContact.getNameString(), validMeeting.getTitleString()));
         CommandResult result = command.execute(model);
         assertEquals(expectedCommandResult, result);
 

--- a/src/test/java/seedu/address/logic/commands/DeleteContactFromMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteContactFromMeetingCommandTest.java
@@ -31,9 +31,9 @@ class DeleteContactFromMeetingCommandTest {
         model.setMeeting(validMeeting, editedMeeting);
         model.updateFilteredMeetingList(Model.PREDICATE_SHOW_ALL_MEETINGS);
         DeleteContactFromMeetingCommand command = new DeleteContactFromMeetingCommand(editedMeeting.getTitle()
-            .toString(), validContact.getName().toString());
+            .toString(), validContact.getNameString());
         CommandResult expectedCommandResult = new CommandResult(String.format("Removed contact '%s' from Meeting '%s'",
-            validContact.getName().toString(), editedMeeting.getTitle().toString()));
+            validContact.getNameString(), editedMeeting.getTitleString()));
         CommandResult result = command.execute(model);
         assertEquals(expectedCommandResult, result);
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteContactFromMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteContactFromMeetingCommandTest.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.contact.Contact;
+import seedu.address.model.meeting.Meeting;
+
+class DeleteContactFromMeetingCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    void execute() throws CommandException {
+        Contact validContact = model.getFilteredContactList().get(INDEX_FIRST.getZeroBased());
+        Meeting validMeeting = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
+        ArrayList<Contact> listOfContacts = new ArrayList<>();
+        listOfContacts.add(validContact);
+        Meeting editedMeeting = new Meeting(
+            validMeeting.getTitle(), validMeeting.getTime(), validMeeting.getPlace(),
+            validMeeting.getDescription(), validMeeting.getNotes(), listOfContacts);
+        model.setMeeting(validMeeting, editedMeeting);
+        model.updateFilteredMeetingList(Model.PREDICATE_SHOW_ALL_MEETINGS);
+        DeleteContactFromMeetingCommand command = new DeleteContactFromMeetingCommand(editedMeeting.getTitle()
+            .toString(), validContact.getName().toString());
+        CommandResult expectedCommandResult = new CommandResult(String.format("Removed contact '%s' from Meeting '%s'",
+            validContact.getName().toString(), editedMeeting.getTitle().toString()));
+        CommandResult result = command.execute(model);
+        assertEquals(expectedCommandResult, result);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ViewMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewMeetingCommandTest.java
@@ -30,7 +30,7 @@ public class ViewMeetingCommandTest {
         Meeting meetingToDisplay = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
         ViewMeetingCommand viewMeetingCommand = new ViewMeetingCommand(INDEX_FIRST);
         String expectedMessage = String.format(ViewMeetingCommand.MESSAGE_VIEW_MEETING_SUCCESS,
-                Messages.formatMeeting(meetingToDisplay));
+                Messages.formatMeeting(meetingToDisplay)) + "\n" + Messages.formatMeetingContacts(meetingToDisplay);
         String expectedNote = meetingToDisplay.getNotes().toString().replace("[", "").replace("]", "");
 
         assertCommandSuccess(viewMeetingCommand, model, expectedMessage, expectedNote);
@@ -51,7 +51,7 @@ public class ViewMeetingCommandTest {
         Meeting meetingToDisplay = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
         ViewMeetingCommand viewMeetingCommand = new ViewMeetingCommand(INDEX_FIRST);
         String expectedMessage = String.format(ViewMeetingCommand.MESSAGE_VIEW_MEETING_SUCCESS,
-                Messages.formatMeeting(meetingToDisplay));
+                Messages.formatMeeting(meetingToDisplay)) + "\n" + Messages.formatMeetingContacts(meetingToDisplay);
         String expectedNote = meetingToDisplay.getNotes().toString().replace("[", "").replace("]", "");
 
         assertCommandSuccess(viewMeetingCommand, model, expectedMessage, expectedNote);

--- a/src/test/java/seedu/address/logic/commands/ViewMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewMeetingCommandTest.java
@@ -30,7 +30,7 @@ public class ViewMeetingCommandTest {
         Meeting meetingToDisplay = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
         ViewMeetingCommand viewMeetingCommand = new ViewMeetingCommand(INDEX_FIRST);
         String expectedMessage = String.format(ViewMeetingCommand.MESSAGE_VIEW_MEETING_SUCCESS,
-                Messages.formatMeeting(meetingToDisplay)) + "\n" + Messages.formatMeetingContacts(meetingToDisplay);
+                Messages.formatMeeting(meetingToDisplay));
         String expectedNote = meetingToDisplay.getNotes().toString().replace("[", "").replace("]", "");
 
         assertCommandSuccess(viewMeetingCommand, model, expectedMessage, expectedNote);
@@ -51,7 +51,7 @@ public class ViewMeetingCommandTest {
         Meeting meetingToDisplay = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
         ViewMeetingCommand viewMeetingCommand = new ViewMeetingCommand(INDEX_FIRST);
         String expectedMessage = String.format(ViewMeetingCommand.MESSAGE_VIEW_MEETING_SUCCESS,
-                Messages.formatMeeting(meetingToDisplay)) + "\n" + Messages.formatMeetingContacts(meetingToDisplay);
+                Messages.formatMeeting(meetingToDisplay));
         String expectedNote = meetingToDisplay.getNotes().toString().replace("[", "").replace("]", "");
 
         assertCommandSuccess(viewMeetingCommand, model, expectedMessage, expectedNote);

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import java.util.Arrays;
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddContactCommand;
+import seedu.address.logic.commands.AddContactToMeetingCommand;
 import seedu.address.logic.commands.AddMeetingCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteContactCommand;
@@ -27,6 +29,9 @@ import seedu.address.logic.commands.ListContactCommand;
 import seedu.address.logic.commands.ViewContactCommand;
 import seedu.address.logic.commands.ViewMeetingCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.NameContainsKeywordsPredicate;
 import seedu.address.model.meeting.Meeting;
@@ -38,6 +43,7 @@ import seedu.address.testutil.MeetingBuilder;
 
 public class AddressBookParserTest {
 
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private final AddressBookParser parser = new AddressBookParser();
 
     @Test
@@ -60,10 +66,10 @@ public class AddressBookParserTest {
         Meeting meeting = new MeetingBuilder().build();
         AddMeetingCommand expectedCommand = new AddMeetingCommand(meeting);
         String userInput = AddMeetingCommand.COMMAND_WORD
-                + " -title" + MeetingBuilder.DEFAULT_TITLE
-                + " -time" + MeetingBuilder.DEFAULT_TIME
-                + " -place" + MeetingBuilder.DEFAULT_PLACE
-                + " -desc" + MeetingBuilder.DEFAULT_DESCRIPTION;
+            + " -title" + MeetingBuilder.DEFAULT_TITLE
+            + " -time" + MeetingBuilder.DEFAULT_TIME
+            + " -place" + MeetingBuilder.DEFAULT_PLACE
+            + " -desc" + MeetingBuilder.DEFAULT_DESCRIPTION;
         AddMeetingCommand actualCommand = (AddMeetingCommand) parser.parseCommand(userInput);
         assertEquals(expectedCommand, actualCommand);
     }
@@ -77,6 +83,17 @@ public class AddressBookParserTest {
     }
 
     @Test
+    public void parseCommand_addContactToMeeting() throws Exception {
+        Meeting meeting = new MeetingBuilder().build();
+        Contact contact = new ContactBuilder().build();
+        String userInput = "add contact to meeting -n " + contact.getNameString() + " -title" + meeting.getTitleString();
+        AddContactToMeetingCommand expectedCommand = new AddContactToMeetingCommand(
+            meeting.getTitleString(), contact.getNameString());
+        AddContactToMeetingCommand actualCommand = (AddContactToMeetingCommand) parser.parseCommand(userInput);
+        assertEquals(expectedCommand, actualCommand);
+    }
+
+    @Test
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " -id 3") instanceof ClearCommand);
@@ -85,7 +102,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteContactCommand command = (DeleteContactCommand) parser.parseCommand(
-                DeleteContactCommand.COMMAND_WORD + " -id " + INDEX_FIRST.getOneBased());
+            DeleteContactCommand.COMMAND_WORD + " -id " + INDEX_FIRST.getOneBased());
         assertEquals(new DeleteContactCommand(INDEX_FIRST), command);
     }
 
@@ -94,7 +111,7 @@ public class AddressBookParserTest {
         Contact contact = new ContactBuilder().build();
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder(contact).build();
         String input = EditContactCommand.COMMAND_WORD + " -id " + INDEX_FIRST.getOneBased() + " "
-                + ContactUtil.getEditContactDescriptorDetails(descriptor);
+            + ContactUtil.getEditContactDescriptorDetails(descriptor);
         EditContactCommand command = (EditContactCommand) parser.parseCommand(input);
 
         assertEquals(new EditContactCommand(INDEX_FIRST, descriptor), command);
@@ -130,7 +147,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-                -> parser.parseCommand(""));
+            -> parser.parseCommand(""));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -86,7 +86,8 @@ public class AddressBookParserTest {
     public void parseCommand_addContactToMeeting() throws Exception {
         Meeting meeting = new MeetingBuilder().build();
         Contact contact = new ContactBuilder().build();
-        String userInput = "add contact to meeting -n " + contact.getNameString() + " -title" + meeting.getTitleString();
+        String userInput = "add contact to meeting -n " + contact.getNameString()
+            + " -title" + meeting.getTitleString();
         AddContactToMeetingCommand expectedCommand = new AddContactToMeetingCommand(
             meeting.getTitleString(), contact.getNameString());
         AddContactToMeetingCommand actualCommand = (AddContactToMeetingCommand) parser.parseCommand(userInput);

--- a/src/test/java/seedu/address/model/meeting/MeetingTest.java
+++ b/src/test/java/seedu/address/model/meeting/MeetingTest.java
@@ -34,7 +34,8 @@ public class MeetingTest {
 
         String expected = Meeting.class.getCanonicalName() + "{title=" + MeetingBuilder.DEFAULT_TITLE
                 + ", time=" + MeetingBuilder.DEFAULT_TIME + ", place=" + MeetingBuilder.DEFAULT_PLACE
-                + ", description=" + MeetingBuilder.DEFAULT_DESCRIPTION + ", notes=[]}";
+                + ", description=" + MeetingBuilder.DEFAULT_DESCRIPTION + ", notes=[]"
+                + ", contacts=[]}";
 
         assertEquals(expected, meeting.toString());
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedMeetingTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedMeetingTest.java
@@ -28,6 +28,9 @@ public class JsonAdaptedMeetingTest {
     private static final List<JsonAdaptedNote> VALID_NOTES = CS2103.getNotes().stream()
             .map(JsonAdaptedNote::new)
             .collect(Collectors.toList());
+    private static final List<JsonAdaptedContact> VALID_CONTACTS = CS2103.getContacts().stream()
+            .map(JsonAdaptedContact::new)
+            .collect(Collectors.toList());
 
     @Test
     public void toModelType_validMeetingDetails_returnsMeeting() throws Exception {
@@ -38,7 +41,8 @@ public class JsonAdaptedMeetingTest {
     @Test
     public void toModelType_invalidTitle_throwsIllegalValueException() {
         JsonAdaptedMeeting meeting =
-                new JsonAdaptedMeeting(INVALID_TITLE, VALID_TIME, VALID_PLACE, VALID_DESCRIPTION, VALID_NOTES);
+                new JsonAdaptedMeeting(INVALID_TITLE, VALID_TIME, VALID_PLACE,
+                        VALID_DESCRIPTION, VALID_NOTES, VALID_CONTACTS);
         String expectedMessage = Title.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, meeting::toModelType);
     }
@@ -46,7 +50,7 @@ public class JsonAdaptedMeetingTest {
     @Test
     public void toModelType_nullTitle_throwsIllegalValueException() {
         JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(null, VALID_TIME, VALID_PLACE, VALID_DESCRIPTION,
-                VALID_NOTES);
+                VALID_NOTES, VALID_CONTACTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Title.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, meeting::toModelType);
     }
@@ -54,7 +58,8 @@ public class JsonAdaptedMeetingTest {
     @Test
     public void toModelType_invalidTime_throwsIllegalValueException() {
         JsonAdaptedMeeting meeting =
-                new JsonAdaptedMeeting(VALID_TITLE, INVALID_TIME, VALID_PLACE, VALID_DESCRIPTION, VALID_NOTES);
+                new JsonAdaptedMeeting(VALID_TITLE, INVALID_TIME, VALID_PLACE,
+                        VALID_DESCRIPTION, VALID_NOTES, VALID_CONTACTS);
         String expectedMessage = Time.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, meeting::toModelType);
     }
@@ -62,7 +67,7 @@ public class JsonAdaptedMeetingTest {
     @Test
     public void toModelType_nullTime_throwsIllegalValueException() {
         JsonAdaptedMeeting meeting =
-                new JsonAdaptedMeeting(VALID_TITLE, null, VALID_PLACE, VALID_DESCRIPTION, VALID_NOTES);
+                new JsonAdaptedMeeting(VALID_TITLE, null, VALID_PLACE, VALID_DESCRIPTION, VALID_NOTES, VALID_CONTACTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Time.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, meeting::toModelType);
     }
@@ -70,7 +75,8 @@ public class JsonAdaptedMeetingTest {
     @Test
     public void toModelType_invalidPlace_throwsIllegalValueException() {
         JsonAdaptedMeeting meeting =
-                new JsonAdaptedMeeting(VALID_TITLE, VALID_TIME, INVALID_PLACE, VALID_DESCRIPTION, VALID_NOTES);
+                new JsonAdaptedMeeting(VALID_TITLE, VALID_TIME, INVALID_PLACE,
+                        VALID_DESCRIPTION, VALID_NOTES, VALID_CONTACTS);
         String expectedMessage = Place.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, meeting::toModelType);
     }
@@ -78,7 +84,7 @@ public class JsonAdaptedMeetingTest {
     @Test
     public void toModelType_nullPlace_throwsIllegalValueException() {
         JsonAdaptedMeeting meeting =
-                new JsonAdaptedMeeting(VALID_TITLE, VALID_TIME, null, VALID_DESCRIPTION, VALID_NOTES);
+                new JsonAdaptedMeeting(VALID_TITLE, VALID_TIME, null, VALID_DESCRIPTION, VALID_NOTES, VALID_CONTACTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Place.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, meeting::toModelType);
     }
@@ -86,7 +92,7 @@ public class JsonAdaptedMeetingTest {
     @Test
     public void toModelType_nullDescription_throwsIllegalValueException() {
         JsonAdaptedMeeting meeting =
-                new JsonAdaptedMeeting(VALID_TITLE, VALID_TIME, VALID_PLACE, null, VALID_NOTES);
+                new JsonAdaptedMeeting(VALID_TITLE, VALID_TIME, VALID_PLACE, null, VALID_NOTES, VALID_CONTACTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Description.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, meeting::toModelType);
     }

--- a/src/test/java/seedu/address/testutil/MeetingBuilder.java
+++ b/src/test/java/seedu/address/testutil/MeetingBuilder.java
@@ -1,5 +1,7 @@
 package seedu.address.testutil;
 
+import static seedu.address.model.util.SampleDataUtil.getNoteSet;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
@@ -11,7 +13,6 @@ import seedu.address.model.meeting.Place;
 import seedu.address.model.meeting.Time;
 import seedu.address.model.meeting.Title;
 import seedu.address.model.note.Note;
-import seedu.address.model.util.SampleDataUtil;
 
 /**
  * A utility class to help with building Person objects.
@@ -96,7 +97,7 @@ public class MeetingBuilder {
      * Sets the {@code Notes} of the {@code Meeting} that we are building.
      */
     public MeetingBuilder withNotes(String... notes) {
-        this.notes = SampleDataUtil.getNoteSet(notes);
+        this.notes = getNoteSet(notes);
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/MeetingBuilder.java
+++ b/src/test/java/seedu/address/testutil/MeetingBuilder.java
@@ -1,8 +1,10 @@
 package seedu.address.testutil;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
+import seedu.address.model.contact.Contact;
 import seedu.address.model.meeting.Description;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.meeting.Place;
@@ -32,6 +34,7 @@ public class MeetingBuilder {
 
     private Description description;
     private Set<Note> notes;
+    private ArrayList<Contact> contacts;
 
     /**
      * Creates a {@code MeetingBuilder} with the default details.
@@ -42,6 +45,7 @@ public class MeetingBuilder {
         place = new Place(DEFAULT_PLACE);
         description = new Description(DEFAULT_DESCRIPTION);
         notes = new HashSet<>();
+        contacts = new ArrayList<>();
     }
 
     /**
@@ -53,6 +57,7 @@ public class MeetingBuilder {
         place = meetingToCopy.getPlace();
         description = meetingToCopy.getDescription();
         notes = new HashSet<>(meetingToCopy.getNotes());
+        contacts = new ArrayList<>(meetingToCopy.getContacts());
     }
 
     /**
@@ -90,12 +95,12 @@ public class MeetingBuilder {
     /**
      * Sets the {@code Notes} of the {@code Meeting} that we are building.
      */
-    public MeetingBuilder withNotes(String ... notes) {
+    public MeetingBuilder withNotes(String... notes) {
         this.notes = SampleDataUtil.getNoteSet(notes);
         return this;
     }
 
     public Meeting build() {
-        return new Meeting(title, time, place, description, notes);
+        return new Meeting(title, time, place, description, notes, contacts);
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalAddressBook.java
+++ b/src/test/java/seedu/address/testutil/TypicalAddressBook.java
@@ -26,46 +26,46 @@ import seedu.address.model.meeting.Meeting;
 public class TypicalAddressBook {
 
     public static final Contact ALICE = new ContactBuilder().withName("Alice Pauline")
-            .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-            .withPhone("94351253")
-            .withTags("friends")
-            .build();
+        .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
+        .withPhone("94351253")
+        .withTags("friends")
+        .build();
     public static final Contact BENSON = new ContactBuilder().withName("Benson Meier")
-            .withAddress("311, Clementi Ave 2, #02-25")
-            .withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends")
-            .withNotes("Likes chicken", "Hates tiramisu").build();
+        .withAddress("311, Clementi Ave 2, #02-25")
+        .withEmail("johnd@example.com").withPhone("98765432")
+        .withTags("owesMoney", "friends")
+        .withNotes("Likes chicken", "Hates tiramisu").build();
     public static final Contact CARL = new ContactBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withAddress("wall street")
-            .withNotes("Enjoys rom-coms").build();
+        .withEmail("heinz@example.com").withAddress("wall street")
+        .withNotes("Enjoys rom-coms").build();
     public static final Contact DANIEL = new ContactBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends")
-            .withNotes("Hates football").build();
+        .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends")
+        .withNotes("Hates football").build();
     public static final Contact ELLE = new ContactBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@example.com").withAddress("michegan ave")
-            .withNotes("Keyboard geek").build();
+        .withEmail("werner@example.com").withAddress("michegan ave")
+        .withNotes("Keyboard geek").build();
     public static final Contact FIONA = new ContactBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@example.com").withAddress("little tokyo")
-            .withNotes("Gym rat").build();
+        .withEmail("lydia@example.com").withAddress("little tokyo")
+        .withNotes("Gym rat").build();
     public static final Contact GEORGE = new ContactBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withAddress("4th street")
-            .withNotes("Likes bread").build();
+        .withEmail("anna@example.com").withAddress("4th street")
+        .withNotes("Likes bread").build();
 
     // Manually added
     public static final Contact HOON = new ContactBuilder().withName("Hoon Meier").withPhone("8482424")
-            .withEmail("stefan@example.com").withAddress("little india")
-            .withNotes("Likes chicken").build();
+        .withEmail("stefan@example.com").withAddress("little india")
+        .withNotes("Likes chicken").build();
     public static final Contact IDA = new ContactBuilder().withName("Ida Mueller").withPhone("8482131")
-            .withEmail("hans@example.com").withAddress("chicago ave")
-            .withNotes("Likes chicken").build();
+        .withEmail("hans@example.com").withAddress("chicago ave")
+        .withNotes("Likes chicken").build();
 
     // Manually added - Contact's details found in {@code CommandTestUtil}
     public static final Contact AMY = new ContactBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND)
-            .withNotes(VALID_NOTE_AMY).build();
+        .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND)
+        .withNotes(VALID_NOTE_AMY).build();
     public static final Contact BOB = new ContactBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
-            .build();
+        .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+        .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 
@@ -94,7 +94,8 @@ public class TypicalAddressBook {
         .withDescription("Picnic with Sandwiches!")
         .build();
 
-    private TypicalAddressBook() {} // prevents instantiation
+    private TypicalAddressBook() {
+    } // prevents instantiation
 
     /**
      * Returns an {@code AddressBook} with all the typical contacts.


### PR DESCRIPTION
Allows users to better organize their meetings by providing the functionality to add or delete Contacts to/from Meetings.

Let's,
*Implement AddContactToMeetingCommand allowing users to link Contacts to specific Meetings. 
*Implement DeleteContactFromMeetingCommand enabling the removal of Contacts from existing Meetings.

### Description
[Provide a brief description of the changes made in this pull request.]

### Related Issue(s)
[#107](https://github.com/AY2324S1-CS2103-W14-2/tp/issues/107) 

### Checklist
[Make sure to check the boxes that apply. If an item is not applicable, you can remove it.]

- [x] Unit tests have been added or updated.
- [x] Code has been tested locally and works as expected.
- [x] Dependencies have been checked and updated, if necessary.
- [x] All code follows the project's coding standards and style guidelines.


### To-Do

- [x] Implement AddContactToMeetingCommand
- [x] Implement DeleteContactFromMeetingCommand
