### PR TITLE
Add support for modes within the application

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -25,15 +25,29 @@ Notenote provide tools for organizing and categorizing contacts in a systematic 
 
 ---
 
+### Mode
+- **What it does**: Toggles the mode of the application between "contacts" and "meetings". 
+    The application defaults to the "contacts" mode. The mode of the application determines the
+    context in which the following commands are executed upon:
+  1. add 
+  2. list
+
+- **Command Format**: `mode`
+
+- **Expected Outputs**:
+    - “Application mode set: [CURRENT_MODE].”
+
+---
+
 ## Contact Management:
 
 ### Create New Contact
 
-- **What it does**: Adds a new contact to the list.
+- **What it does**: Adds a new contact to the list when in the "contacts" mode.
 
-- **Command Format**: `add contact -n CONTACT_NAME -p PHONE_NUMBER -e EMAIL_ADDRESS -a RESIDENTIAL_ADDRESS [-t TAGS]`
+- **Command Format**: `add -n CONTACT_NAME -p PHONE_NUMBER -e EMAIL_ADDRESS -a RESIDENTIAL_ADDRESS [-t TAGS]`
 
-- **Example**: `add contact -n Sarah Woo -p 82775346 -e sarah.woo@gmail.com -a Blk227 Sims Drive`
+- **Example**: `add -n Sarah Woo -p 82775346 -e sarah.woo@gmail.com -a Blk227 Sims Drive`
 
 - **Acceptable Values**:
     - CONTACT_NAME: String, at least 2 characters long.
@@ -49,11 +63,11 @@ Notenote provide tools for organizing and categorizing contacts in a systematic 
 
 ### View a Contact
 
-- **What it does**: Displays details of a specific contact.
+- **What it does**: Displays details of a specific contact when in the "contacts" mode.
 
-- **Command Format**: `view contact -[CONTACT_ID or CONTACT_NAME]`
+- **Command Format**: `view -[CONTACT_ID or CONTACT_NAME]`
 
-- **Example**: `view contact -Sarah`
+- **Example**: `view -Sarah`
 
 - **Acceptable Values**:
     - CONTACT_ID: Non-negative integer.
@@ -71,9 +85,9 @@ Notenote provide tools for organizing and categorizing contacts in a systematic 
 
 ### List All Contacts
 
-- **What it does**: Shows all contacts in the list.
+- **What it does**: Shows all contacts in the list when in the "contacts" mode.
 
-- **Command Format**: `list contacts`
+- **Command Format**: `list`
 
 - **Expected Outputs**:
     - Success: List of all contacts.
@@ -84,11 +98,11 @@ Notenote provide tools for organizing and categorizing contacts in a systematic 
 
 ### Delete a Contact
 
-- **What it does**: Removes a contact based on the given ID.
+- **What it does**: Removes a contact based on the given ID when in the "contacts" mode.
 
-- **Command Format**: `delete contact -id [CONTACT_ID]`
+- **Command Format**: `delete -id [CONTACT_ID]`
 
-- **Example**: `delete contact -id 3`
+- **Example**: `delete -id 3`
 
 - **Acceptable Values**:
     - CONTACT_ID: Non-negative integer.
@@ -105,11 +119,11 @@ Notenote provide tools for organizing and categorizing contacts in a systematic 
 
 ### Create a New Meeting
 
-- **What it does**: Organizes a new meeting with optional notes and contacts.
+- **What it does**: Organizes a new meeting with optional notes and contacts when in the "meetings" mode.
 
-- **Command Format**: `add meeting -title MEETING_NAME -time DD/MM/YYYY HH:MM -place LOCATION[-desc DESCRIPTION]`
+- **Command Format**: `add -title MEETING_NAME -time DD/MM/YYYY HH:MM -place LOCATION[-desc DESCRIPTION]`
 
-- **Example**: `add meeting -title Project Discussion -time 03/10/2023 15:00 -place Terrace -desc Discussing milestones`
+- **Example**: `add -title Project Discussion -time 03/10/2023 15:00 -place Terrace -desc Discussing milestones`
 
 - **Acceptable Values**:
     - MEETING_NAME: String, at least 2 characters long.
@@ -126,11 +140,11 @@ Notenote provide tools for organizing and categorizing contacts in a systematic 
 
 ### View a Meeting
 
-- **What it does**: Displays details of a specific meeting.
+- **What it does**: Displays details of a specific meeting when in the "meetings" mode.
 
-- **Command Format**: `view meeting -[MEETING_ID or MEETING_NAME]`
+- **Command Format**: `view -[MEETING_ID or MEETING_NAME]`
 
-- **Example**: `view meeting Project Discussion`
+- **Example**: `view Project Discussion`
 
 - **Acceptable Values**:
     - MEETING_ID: Non-negative integer.
@@ -145,9 +159,9 @@ Notenote provide tools for organizing and categorizing contacts in a systematic 
 
 ### List All Meetings
 
-- **What it does**: Shows a list of all meetings.
+- **What it does**: Shows a list of all meetings when in the "meetings" mode.
 
-- **Command Format**: `list meetings`
+- **Command Format**: `list`
 
 - **Expected Outputs**:
     - Success: List of all meetings.
@@ -159,11 +173,11 @@ Notenote provide tools for organizing and categorizing contacts in a systematic 
 
 ### Delete a Meeting
 
-- **What it does**: Cancels a meeting based on the given ID or name.
+- **What it does**: Cancels a meeting based on the given ID or name  when in the "meetings" mode.
 
-- **Command Format**: `delete meeting -MEETING_ID`
+- **Command Format**: `delete -MEETING_ID`
 
-- **Example**: `delete meeting Project Discussion`
+- **Example**: `delete Project Discussion`
 
 - **Acceptable Values**:
     - MEETING_ID: Non-negative integer.
@@ -179,11 +193,11 @@ Notenote provide tools for organizing and categorizing contacts in a systematic 
 
 ### Add Contact to Meeting
 
-- **What it does**: Adds a contact to an existing meeting as a participant.
+- **What it does**: Adds a contact to an existing meeting as a participant when in the "meetings" mode.
 
-- **Command Format**: `add contact to meeting -n CONTACT_NAME -title MEETING_NAME`
+- **Command Format**: `add contact -n CONTACT_NAME -title MEETING_NAME`
 
-- **Example**: `add contact to meeting -n Sarah Woo -title Project Discussion`
+- **Example**: `add contact -n Sarah Woo -title Project Discussion`
 
 - **Acceptable Values**:
     - MEETING_NAME: String, at least 2 characters long. Not case sensitive.
@@ -201,11 +215,11 @@ Notenote provide tools for organizing and categorizing contacts in a systematic 
 
 ### Delete Contact from Meeting
 
-- **What it does**: Removes a contact from an existing meeting.
+- **What it does**: Removes a contact from an existing meeting when in the "meetings" mode.
 
-- **Command Format**: `delete contact from meeting -n CONTACT_NAME -title MEETING_NAME`
+- **Command Format**: `delete contact -n CONTACT_NAME -title MEETING_NAME`
 
-- **Example**: `delete contact from meeting -n Sarah Woo -title Project Discussion`
+- **Example**: `delete contact -n Sarah Woo -title Project Discussion`
 
 - **Acceptable Values**:
     - MEETING_NAME: String, at least 2 characters long. Not case sensitive.
@@ -226,15 +240,15 @@ Notenote provide tools for organizing and categorizing contacts in a systematic 
 
 ### Add Notes to a Contact or Meeting
 
-- **What it does**: Associates notes with a specific contact or meeting.
+- **What it does**: Associates notes with a specific contact or meeting
 
 - **Command Format**:
-    - For Contacts: `add contact note -id CONTACT_ID_or_CONTACT_NAME -note NOTES`
-    - For Meetings: `add meeting note -id MEETING_ID_or_MEETING_NAME -note NOTES`
+    - For Contacts when in "contacts" mode: `add note -id CONTACT_ID_or_CONTACT_NAME -c NOTES`
+    - For Meetings when in "Meetings" mode: `add note -id MEETING_ID_or_MEETING_NAME -m NOTES`
 
 - **Examples**:
-    - `add contact note -id 5 -note Has a dog named Benny`
-    - `add meeting note -id Project Discussion -note Agenda: Discuss Q2 results`
+    - `add note -id 5 -note Has a dog named Benny`
+    - `add note -id Project Discussion -note Agenda: Discuss Q2 results`
 
 - **Acceptable Values**:
     - CONTACT_ID: Non-negative integer.
@@ -259,12 +273,12 @@ Notenote provide tools for organizing and categorizing contacts in a systematic 
 - **What it does**: Removes specified notes from a contact or meeting.
 
 - **Command Format**:
-    - For Contacts: `delete contact note -id CONTACT_ID_or_CONTACT_NAME -index NOTE_INDEX`
-    - For Meetings: `delete meeting note -id MEETING_ID_or_MEETING_NAME -index NOTE_INDEX`
+    - For Contacts when in "contacts" mode: `delete note -id CONTACT_ID_or_CONTACT_NAME -index NOTE_INDEX`
+    - For Meetings when in "Meetings" mode: `delete note -id MEETING_ID_or_MEETING_NAME -index NOTE_INDEX`
 
 - **Examples**:
-    - `delete contact note -id 5 -index 2`
-    - `delete meeting note -id Project Discussion -index 1`
+    - `delete note -id 5 -index 2`
+    - `delete note -id Project Discussion -index 1`
 
 - **Acceptable Values**:
     - CONTACT_ID: Non-negative integer.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -48,7 +48,7 @@ public class LogicManager implements Logic {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;
-        Command command = addressBookParser.parseCommand(commandText);
+        Command command = addressBookParser.parseCommand(commandText, model);
         commandResult = command.execute(model);
 
         try {

--- a/src/main/java/seedu/address/logic/commands/AddContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactCommand.java
@@ -19,7 +19,7 @@ import seedu.address.model.contact.Contact;
  */
 public class AddContactCommand extends Command {
 
-    public static final String COMMAND_WORD = "add contact";
+    public static final String COMMAND_WORD = "add";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a contact to the address book. "
             + "Parameters: "

--- a/src/main/java/seedu/address/logic/commands/AddContactToMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactToMeetingCommand.java
@@ -16,7 +16,7 @@ import seedu.address.model.meeting.Meeting;
  * Adds a contact to a meeting.
  */
 public class AddContactToMeetingCommand extends Command {
-    public static final String COMMAND_WORD = "add contact to meeting";
+    public static final String COMMAND_WORD = "add contact";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
         + ": Adds the participants to the meeting identified "

--- a/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
@@ -1,6 +1,11 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_MEETING;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PLACE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -13,9 +18,21 @@ import seedu.address.model.meeting.Meeting;
  */
 public class AddMeetingCommand extends Command {
 
-    public static final String COMMAND_WORD = "add meeting";
+    public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + "blahblah fill in later";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a meeting to the address book. "
+            + "Parameters: "
+            + PREFIX_TITLE + "TITLE "
+            + PREFIX_TIME + "TIME "
+            + PREFIX_PLACE + "PLACE "
+            + PREFIX_DESCRIPTION + "DESCRIPTION "
+            + PREFIX_NOTE_MEETING + "NOTE"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_TITLE + " Project Discussion "
+            + PREFIX_TIME + " 03/10/2023 15:00 "
+            + PREFIX_PLACE + " Terrace "
+            + PREFIX_DESCRIPTION + " Discussing milestones "
+            + PREFIX_NOTE_MEETING + "test note 1";
 
     public static final String MESSAGE_SUCCESS = "New meeting added: %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/AddMeetingNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMeetingNoteCommand.java
@@ -20,7 +20,7 @@ import seedu.address.model.note.Note;
  */
 public class AddMeetingNoteCommand extends Command {
 
-    public static final String COMMAND_WORD = "add meeting note";
+    public static final String COMMAND_WORD = "add note";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Edits the note of the meeting identified "

--- a/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
@@ -20,7 +20,7 @@ import seedu.address.model.note.Note;
  */
 public class AddNoteCommand extends Command {
 
-    public static final String COMMAND_WORD = "add contact note";
+    public static final String COMMAND_WORD = "add note";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Edits the note of the person identified "

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -10,7 +10,7 @@ import seedu.address.model.Model;
  */
 public class ClearCommand extends Command {
 
-    public static final String COMMAND_WORD = "clear contacts";
+    public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
 
 

--- a/src/main/java/seedu/address/logic/commands/DeleteContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteContactCommand.java
@@ -16,7 +16,7 @@ import seedu.address.model.contact.Contact;
  */
 public class DeleteContactCommand extends Command {
 
-    public static final String COMMAND_WORD = "delete contact";
+    public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the contact identified by the index number used in the displayed contact list.\n"

--- a/src/main/java/seedu/address/logic/commands/DeleteContactFromMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteContactFromMeetingCommand.java
@@ -16,7 +16,7 @@ import seedu.address.model.meeting.Meeting;
  * Deletes a contact from a meeting identified using it's name
  */
 public class DeleteContactFromMeetingCommand extends Command {
-    public static final String COMMAND_WORD = "delete contact from meeting";
+    public static final String COMMAND_WORD = "delete contact";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
         + ": Removes the participants to the meeting identified "

--- a/src/main/java/seedu/address/logic/commands/DeleteMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteMeetingCommand.java
@@ -16,7 +16,7 @@ import seedu.address.model.meeting.Meeting;
  */
 public class DeleteMeetingCommand extends Command {
 
-    public static final String COMMAND_WORD = "delete meeting";
+    public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the meeting identified by the index number used in the displayed meeting list.\n"

--- a/src/main/java/seedu/address/logic/commands/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditContactCommand.java
@@ -35,7 +35,7 @@ import seedu.address.model.tag.Tag;
  */
 public class EditContactCommand extends Command {
 
-    public static final String COMMAND_WORD = "edit contact";
+    public static final String COMMAND_WORD = "edit";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the contact identified "
             + "by the index number used in the displayed contact list. "

--- a/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
@@ -34,7 +34,7 @@ import seedu.address.model.note.Note;
  */
 public class EditMeetingCommand extends Command {
 
-    public static final String COMMAND_WORD = "edit meeting";
+    public static final String COMMAND_WORD = "edit";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the meeting identified "
             + "by the index number used in the displayed meeting list. "

--- a/src/main/java/seedu/address/logic/commands/FindContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindContactCommand.java
@@ -13,7 +13,7 @@ import seedu.address.model.contact.NameContainsKeywordsPredicate;
  */
 public class FindContactCommand extends Command {
 
-    public static final String COMMAND_WORD = "find contact";
+    public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all contacts whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"

--- a/src/main/java/seedu/address/logic/commands/ListContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListContactCommand.java
@@ -11,7 +11,7 @@ import seedu.address.model.Model;
  */
 public class ListContactCommand extends Command {
 
-    public static final String COMMAND_WORD = "list contacts";
+    public static final String COMMAND_WORD = "list";
 
     public static final String MESSAGE_SUCCESS = "Listed all contacts.";
 

--- a/src/main/java/seedu/address/logic/commands/ListMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListMeetingCommand.java
@@ -11,7 +11,7 @@ import seedu.address.model.Model;
  */
 public class ListMeetingCommand extends Command {
 
-    public static final String COMMAND_WORD = "list meetings";
+    public static final String COMMAND_WORD = "list";
 
     public static final String MESSAGE_SUCCESS = "Listed all meetings.";
 

--- a/src/main/java/seedu/address/logic/commands/ModeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModeCommand.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.commands.CommandResult.ListType;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.Model.ModeType;
+
+/**
+ * Toggles the mode of Notenote between contacts and meetings mode.
+ */
+public class ModeCommand extends Command {
+
+    public static final String COMMAND_WORD = "mode";
+
+    public static final String MESSAGE_SUCCESS = "Application mode set: %1$s";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        model.changeMode();
+        ModeType mode = model.getMode();
+
+        if (mode == ModeType.CONTACTS) {
+            model.updateFilteredContactList(Model.PREDICATE_SHOW_ALL_CONTACTS);
+            return new CommandResult(String.format(MESSAGE_SUCCESS, mode.toString()), ListType.CONTACTS);
+        } else {
+            model.updateFilteredMeetingList(Model.PREDICATE_SHOW_ALL_MEETINGS);
+            return new CommandResult(String.format(MESSAGE_SUCCESS, mode.toString()), ListType.MEETINGS);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ViewContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewContactCommand.java
@@ -18,8 +18,7 @@ import seedu.address.model.note.Note;
  */
 public class ViewContactCommand extends Command {
 
-    public static final String COMMAND_WORD = "view contact";
-
+    public static final String COMMAND_WORD = "view";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Shows the details of the contact identified by its id in the displayed contact list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"

--- a/src/main/java/seedu/address/logic/commands/ViewMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewMeetingCommand.java
@@ -18,7 +18,7 @@ import seedu.address.model.note.Note;
  */
 public class ViewMeetingCommand extends Command {
 
-    public static final String COMMAND_WORD = "view meeting";
+    public static final String COMMAND_WORD = "view";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
         + ": Shows the details of the meeting identified by its id in the displayed meeting list.\n"

--- a/src/main/java/seedu/address/logic/parser/AddContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddContactCommandParser.java
@@ -9,7 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddContactCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -36,7 +35,7 @@ public class AddContactCommandParser implements Parser<AddContactCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG,
                         PREFIX_NOTE);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
+        if (!ArgumentMultimap.arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddContactCommand.MESSAGE_USAGE));
         }
@@ -53,12 +52,6 @@ public class AddContactCommandParser implements Parser<AddContactCommand> {
         return new AddContactCommand(contact);
     }
 
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
+
 
 }

--- a/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
@@ -9,7 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 
 import java.util.ArrayList;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddMeetingCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -35,7 +34,7 @@ public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_TIME, PREFIX_PLACE,
                         PREFIX_DESCRIPTION);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_TITLE) || !argMultimap.getPreamble().isEmpty()) {
+        if (!ArgumentMultimap.arePrefixesPresent(argMultimap, PREFIX_TITLE) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingCommand.MESSAGE_USAGE));
         }
 
@@ -48,13 +47,5 @@ public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
         Set<Note> noteList = ParserUtil.parseNotes(argMultimap.getAllValues(PREFIX_NOTE_MEETING));
         Meeting meeting = new Meeting(title, time, place, description, noteList, new ArrayList<>());
         return new AddMeetingCommand(meeting);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -25,9 +25,12 @@ import seedu.address.logic.commands.FindContactCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListContactCommand;
 import seedu.address.logic.commands.ListMeetingCommand;
+import seedu.address.logic.commands.ModeCommand;
 import seedu.address.logic.commands.ViewContactCommand;
 import seedu.address.logic.commands.ViewMeetingCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
+import seedu.address.model.Model.ModeType;
 
 /**
  * Parses user input.
@@ -47,12 +50,12 @@ public class AddressBookParser {
      * @return the command based on the user input
      * @throws ParseException if the user input does not conform the expected format
      */
-    public Command parseCommand(String userInput) throws ParseException {
+    public Command parseCommand(String userInput, Model model) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
-
+        final Model.ModeType mode = model.getMode();
         final String commandWord = matcher.group("commandWord").trim();
         final String arguments = " " + matcher.group("arguments");
 
@@ -60,66 +63,87 @@ public class AddressBookParser {
         // log messages such as the one below.
         // Lower level log messages are used sparingly to minimize noise in the code.
         logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
+
         switch (commandWord) {
 
-        case AddContactCommand.COMMAND_WORD:
-            return new AddContactCommandParser().parse(arguments);
-
-        case ViewContactCommand.COMMAND_WORD:
-            return new ViewContactCommandParser().parse(arguments);
-
-        case EditContactCommand.COMMAND_WORD:
-            return new EditContactCommandParser().parse(arguments);
-
-        case DeleteContactCommand.COMMAND_WORD:
-            return new DeleteContactCommandParser().parse(arguments);
-
-        case AddMeetingCommand.COMMAND_WORD:
-            return new AddMeetingCommandParser().parse(arguments);
-
-        case ViewMeetingCommand.COMMAND_WORD:
-            return new ViewMeetingCommandParser().parse(arguments);
-
-        case EditMeetingCommand.COMMAND_WORD:
-            return new EditMeetingCommandParser().parse(arguments);
-
-        case DeleteMeetingCommand.COMMAND_WORD:
-            return new DeleteMeetingCommandParser().parse(arguments);
-
-        case AddContactToMeetingCommand.COMMAND_WORD:
-            return new AddContactToMeetingCommandParser().parse(arguments);
-
-        case DeleteContactFromMeetingCommand.COMMAND_WORD:
-            return new DeleteContactFromMeetingCommandParser().parse(arguments);
-
-        case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
-
-        case FindContactCommand.COMMAND_WORD:
-            return new FindCommandParser().parse(arguments);
-
-        case ListContactCommand.COMMAND_WORD:
-            return new ListContactCommand();
-
-        case ListMeetingCommand.COMMAND_WORD:
-            return new ListMeetingCommand();
-
-        case AddNoteCommand.COMMAND_WORD:
-            return new AddNoteCommandParser().parse(arguments);
-
-        case AddMeetingNoteCommand.COMMAND_WORD:
-            return new AddMeetingNoteCommandParser().parse(arguments);
-
-        case ExitCommand.COMMAND_WORD:
-            return new ExitCommand();
+        case ModeCommand.COMMAND_WORD:
+            return new ModeCommand();
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
 
-        default:
-            logger.finer("This user input caused a ParseException: " + userInput);
-            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
-        }
-    }
+        case ExitCommand.COMMAND_WORD:
+            return new ExitCommand();
 
+        default:
+            break;
+        }
+
+        if (mode == ModeType.CONTACTS) {
+            switch (commandWord) {
+
+            case AddContactCommand.COMMAND_WORD:
+                return new AddContactCommandParser().parse(arguments);
+
+            case ViewContactCommand.COMMAND_WORD:
+                return new ViewContactCommandParser().parse(arguments);
+
+            case EditContactCommand.COMMAND_WORD:
+                return new EditContactCommandParser().parse(arguments);
+
+            case DeleteContactCommand.COMMAND_WORD:
+                return new DeleteContactCommandParser().parse(arguments);
+
+            case ClearCommand.COMMAND_WORD:
+                return new ClearCommand();
+
+            case FindContactCommand.COMMAND_WORD:
+                return new FindCommandParser().parse(arguments);
+
+            case ListContactCommand.COMMAND_WORD:
+                return new ListContactCommand();
+
+            case AddNoteCommand.COMMAND_WORD:
+                return new AddNoteCommandParser().parse(arguments);
+
+            default:
+                break;
+            }
+        }
+
+        if (mode == ModeType.MEETINGS) {
+            switch (commandWord) {
+
+            case AddMeetingCommand.COMMAND_WORD:
+                return new AddMeetingCommandParser().parse(arguments);
+
+            case ViewMeetingCommand.COMMAND_WORD:
+                return new ViewMeetingCommandParser().parse(arguments);
+
+            case EditMeetingCommand.COMMAND_WORD:
+                return new EditMeetingCommandParser().parse(arguments);
+
+            case DeleteMeetingCommand.COMMAND_WORD:
+                return new DeleteMeetingCommandParser().parse(arguments);
+
+            case AddContactToMeetingCommand.COMMAND_WORD:
+                return new AddContactToMeetingCommandParser().parse(arguments);
+
+            case DeleteContactFromMeetingCommand.COMMAND_WORD:
+                return new DeleteContactFromMeetingCommandParser().parse(arguments);
+
+            case ListMeetingCommand.COMMAND_WORD:
+                return new ListMeetingCommand();
+
+            case AddMeetingNoteCommand.COMMAND_WORD:
+                return new AddMeetingNoteCommandParser().parse(arguments);
+
+            default:
+                break;
+            }
+        }
+
+        logger.finer("This user input caused a ParseException: " + userInput);
+        throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -75,4 +75,12 @@ public class ArgumentMultimap {
             throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(duplicatedPrefixes));
         }
     }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -200,4 +200,5 @@ public class ParserUtil {
     public static Description parseDescription(String description) {
         return new Description(description);
     }
+
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -16,6 +16,13 @@ public interface Model {
     Predicate<Contact> PREDICATE_SHOW_ALL_CONTACTS = unused -> true;
     Predicate<Meeting> PREDICATE_SHOW_ALL_MEETINGS = unused -> true;
 
+    /** List of modes that the application can be in. */
+    public enum ModeType {
+        CONTACTS, MEETINGS
+    }
+
+    public final String MESSAGE_CONSTRAINTS = "Mode type should be either contacts or meetings";
+
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
      */
@@ -120,4 +127,8 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredMeetingList(Predicate<Meeting> predicate);
+
+    ModeType getMode();
+
+    void changeMode();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -24,6 +24,7 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Contact> filteredContacts;
     private final FilteredList<Meeting> filteredMeetings;
+    private ModeType mode;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -37,6 +38,9 @@ public class ModelManager implements Model {
         this.userPrefs = new UserPrefs(userPrefs);
         filteredContacts = new FilteredList<>(this.addressBook.getContactList());
         filteredMeetings = new FilteredList<>(this.addressBook.getMeetingList());
+        // Mode always initialized to contact. Can change this to an enum later on.
+        this.mode = ModeType.CONTACTS;
+
     }
 
     public ModelManager() {
@@ -138,7 +142,6 @@ public class ModelManager implements Model {
         return addressBook.hasMeeting(meeting);
     }
 
-    //=========== Filtered Contact List Accessors =============================================================
 
     /**
      * Returns an unmodifiable view of the list of {@code Contact} backed by the internal list of
@@ -164,6 +167,20 @@ public class ModelManager implements Model {
     public void updateFilteredMeetingList(Predicate<Meeting> predicate) {
         requireNonNull(predicate);
         filteredMeetings.setPredicate(predicate);
+    }
+
+    @Override
+    public ModeType getMode() {
+        return mode;
+    }
+
+    @Override
+    public void changeMode() {
+        if (mode == ModeType.CONTACTS) {
+            mode = ModeType.MEETINGS;
+        } else {
+            mode = ModeType.CONTACTS;
+        }
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -61,7 +61,7 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete contact -id 9";
+        String deleteCommand = "delete -id 9";
         assertCommandException(deleteCommand, MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddContactCommandTest.java
@@ -189,6 +189,16 @@ public class AddContactCommandTest {
         public void updateFilteredMeetingList(Predicate<Meeting> predicate) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public ModeType getMode() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void changeMode() {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddMeetingCommandTest.java
@@ -177,6 +177,16 @@ public class AddMeetingCommandTest {
         public void updateFilteredMeetingList(Predicate<Meeting> predicate) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public ModeType getMode() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void changeMode() {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/ModeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ModeCommandTest.java
@@ -1,0 +1,38 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.ModeCommand.MESSAGE_SUCCESS;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.CommandResult.ListType;
+import seedu.address.model.Model;
+import seedu.address.model.Model.ModeType;
+import seedu.address.model.ModelManager;
+
+public class ModeCommandTest {
+    private Model model = new ModelManager();
+    private Model expectedModel = new ModelManager();
+
+    @Test
+    public void execute_mode_success() {
+        // Ensure that both models are initialized in contacts mode
+        assertEquals(model.getMode(), ModeType.CONTACTS);
+        assertEquals(expectedModel.getMode(), ModeType.CONTACTS);
+
+        expectedModel.changeMode();
+        CommandResult expectedCommandResult =
+                new CommandResult(String.format(MESSAGE_SUCCESS, "MEETINGS"), ListType.MEETINGS);
+
+        // Test toggling from contacts to meeting
+        assertCommandSuccess(new ModeCommand(), model, expectedCommandResult, expectedModel);
+
+        expectedModel.changeMode();
+        expectedCommandResult =
+                new CommandResult(String.format(MESSAGE_SUCCESS, "CONTACTS"), ListType.CONTACTS);
+
+        // Test toggling from meetings to contacts
+        assertCommandSuccess(new ModeCommand(), model, expectedCommandResult, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -14,8 +14,6 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.annotation.JsonCreator.Mode;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddContactCommand;
 import seedu.address.logic.commands.AddContactToMeetingCommand;

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -14,6 +14,8 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.annotation.JsonCreator.Mode;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddContactCommand;
 import seedu.address.logic.commands.AddContactToMeetingCommand;
@@ -26,6 +28,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindContactCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListContactCommand;
+import seedu.address.logic.commands.ModeCommand;
 import seedu.address.logic.commands.ViewContactCommand;
 import seedu.address.logic.commands.ViewMeetingCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -153,6 +156,13 @@ public class AddressBookParserTest {
         assertTrue(parser.parseCommand(ListContactCommand.COMMAND_WORD, model) instanceof ListContactCommand);
         assertTrue(parser.parseCommand(ListContactCommand.COMMAND_WORD + " -id 3", model)
                 instanceof ListContactCommand);
+    }
+
+    @Test
+    public void parseCommand_mode() throws Exception {
+        assertTrue(parser.parseCommand(ModeCommand.COMMAND_WORD, model) instanceof ModeCommand);
+        assertTrue(parser.parseCommand(ModeCommand.COMMAND_WORD + " -id 3", model)
+                instanceof ModeCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -30,6 +30,7 @@ import seedu.address.logic.commands.ViewContactCommand;
 import seedu.address.logic.commands.ViewMeetingCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
+import seedu.address.model.Model.ModeType;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.contact.Contact;
@@ -48,21 +49,24 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_addContact() throws Exception {
+        setModeToContacts();
         Contact contact = new ContactBuilder().build();
-        AddContactCommand command = (AddContactCommand) parser.parseCommand(ContactUtil.getAddCommand(contact));
+        AddContactCommand command = (AddContactCommand) parser.parseCommand(ContactUtil.getAddCommand(contact), model);
         assertEquals(new AddContactCommand(contact), command);
     }
 
     @Test
     public void parseCommand_viewContact() throws Exception {
+        setModeToContacts();
         ViewContactCommand expectedCommand = new ViewContactCommand(Index.fromOneBased(1));
         String userInput = ViewContactCommand.COMMAND_WORD + " -id1";
-        ViewContactCommand actualCommand = (ViewContactCommand) parser.parseCommand(userInput);
+        ViewContactCommand actualCommand = (ViewContactCommand) parser.parseCommand(userInput, model);
         assertEquals(expectedCommand, actualCommand);
     }
 
     @Test
     public void parseCommand_addMeeting() throws Exception {
+        setModeToMeetings();
         Meeting meeting = new MeetingBuilder().build();
         AddMeetingCommand expectedCommand = new AddMeetingCommand(meeting);
         String userInput = AddMeetingCommand.COMMAND_WORD
@@ -70,89 +74,120 @@ public class AddressBookParserTest {
             + " -time" + MeetingBuilder.DEFAULT_TIME
             + " -place" + MeetingBuilder.DEFAULT_PLACE
             + " -desc" + MeetingBuilder.DEFAULT_DESCRIPTION;
-        AddMeetingCommand actualCommand = (AddMeetingCommand) parser.parseCommand(userInput);
+        AddMeetingCommand actualCommand = (AddMeetingCommand) parser.parseCommand(userInput, model);
         assertEquals(expectedCommand, actualCommand);
     }
 
     @Test
     public void parseCommand_viewMeeting() throws Exception {
+        setModeToMeetings();
         ViewMeetingCommand expectedCommand = new ViewMeetingCommand(Index.fromOneBased(1));
         String userInput = ViewMeetingCommand.COMMAND_WORD + " -id1";
-        ViewMeetingCommand actualCommand = (ViewMeetingCommand) parser.parseCommand(userInput);
+        ViewMeetingCommand actualCommand = (ViewMeetingCommand) parser.parseCommand(userInput, model);
         assertEquals(expectedCommand, actualCommand);
     }
 
     @Test
     public void parseCommand_addContactToMeeting() throws Exception {
+        setModeToMeetings();
         Meeting meeting = new MeetingBuilder().build();
         Contact contact = new ContactBuilder().build();
-        String userInput = "add contact to meeting -n " + contact.getNameString()
+        String userInput = "add contact -n " + contact.getNameString()
             + " -title" + meeting.getTitleString();
         AddContactToMeetingCommand expectedCommand = new AddContactToMeetingCommand(
             meeting.getTitleString(), contact.getNameString());
-        AddContactToMeetingCommand actualCommand = (AddContactToMeetingCommand) parser.parseCommand(userInput);
+        AddContactToMeetingCommand actualCommand = (AddContactToMeetingCommand) parser.parseCommand(userInput, model);
         assertEquals(expectedCommand, actualCommand);
     }
 
     @Test
     public void parseCommand_clear() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " -id 3") instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, model) instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " -id 3", model) instanceof ClearCommand);
     }
 
     @Test
-    public void parseCommand_delete() throws Exception {
+    public void parseCommand_deleteContact() throws Exception {
+        setModeToContacts();
         DeleteContactCommand command = (DeleteContactCommand) parser.parseCommand(
-            DeleteContactCommand.COMMAND_WORD + " -id " + INDEX_FIRST.getOneBased());
+            DeleteContactCommand.COMMAND_WORD + " -id " + INDEX_FIRST.getOneBased(), model);
         assertEquals(new DeleteContactCommand(INDEX_FIRST), command);
     }
 
     @Test
-    public void parseCommand_edit() throws Exception {
+    public void parseCommand_editContact() throws Exception {
+        setModeToContacts();
         Contact contact = new ContactBuilder().build();
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder(contact).build();
         String input = EditContactCommand.COMMAND_WORD + " -id " + INDEX_FIRST.getOneBased() + " "
             + ContactUtil.getEditContactDescriptorDetails(descriptor);
-        EditContactCommand command = (EditContactCommand) parser.parseCommand(input);
+        EditContactCommand command = (EditContactCommand) parser.parseCommand(input, model);
 
         assertEquals(new EditContactCommand(INDEX_FIRST, descriptor), command);
     }
 
     @Test
     public void parseCommand_exit() throws Exception {
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " -id 3") instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, model) instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " -id 3", model) instanceof ExitCommand);
     }
 
     @Test
-    public void parseCommand_find() throws Exception {
+    public void parseCommand_findContact() throws Exception {
+        setModeToContacts();
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         String input = FindContactCommand.COMMAND_WORD + " -k " + keywords.stream().collect(Collectors.joining(" "));
-        FindContactCommand command = (FindContactCommand) parser.parseCommand(input);
+        FindContactCommand command = (FindContactCommand) parser.parseCommand(input, model);
 
         assertEquals(new FindContactCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 
     @Test
     public void parseCommand_help() throws Exception {
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " -id 3") instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, model) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " -id 3", model) instanceof HelpCommand);
     }
 
     @Test
     public void parseCommand_list() throws Exception {
-        assertTrue(parser.parseCommand(ListContactCommand.COMMAND_WORD) instanceof ListContactCommand);
-        assertTrue(parser.parseCommand(ListContactCommand.COMMAND_WORD + " -id 3") instanceof ListContactCommand);
+        assertTrue(parser.parseCommand(ListContactCommand.COMMAND_WORD, model) instanceof ListContactCommand);
+        assertTrue(parser.parseCommand(ListContactCommand.COMMAND_WORD + " -id 3", model)
+                instanceof ListContactCommand);
     }
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand(""));
+            -> parser.parseCommand("", model));
     }
 
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand", model));
+    }
+
+    @Test
+    public void parseCommand_wrongMode_throwsParseException() {
+        setModeToContacts();
+        String userInput = AddMeetingCommand.COMMAND_WORD
+                + " -title" + MeetingBuilder.DEFAULT_TITLE
+                + " -time" + MeetingBuilder.DEFAULT_TIME
+                + " -place" + MeetingBuilder.DEFAULT_PLACE
+                + " -desc" + MeetingBuilder.DEFAULT_DESCRIPTION;
+        assertThrows(ParseException.class,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        AddContactCommand.MESSAGE_USAGE), () -> parser.parseCommand(userInput, model));
+    }
+
+    private void setModeToContacts() {
+        if (model.getMode() != ModeType.CONTACTS) {
+            model.changeMode();
+        }
+    }
+
+    private void setModeToMeetings() {
+        if (model.getMode() != ModeType.MEETINGS) {
+            model.changeMode();
+        }
     }
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.Model.ModeType;
 import seedu.address.model.contact.NameContainsKeywordsPredicate;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.testutil.AddressBookBuilder;
@@ -106,6 +107,13 @@ public class ModelManagerTest {
     public void hasMeeting_personNotInNotenote_returnsFalse() {
         Meeting meeting = new MeetingBuilder().build();
         assertFalse(modelManager.hasMeeting(meeting));
+    }
+
+    @Test
+    public void changeMode_togglesMode() {
+        ModeType currentMode = modelManager.getMode();
+        modelManager.changeMode();
+        assertFalse(currentMode == modelManager.getMode());
     }
 
     @Test


### PR DESCRIPTION
### Description
Currently users have to type add contact or add meeting in order to add a contact or meeting respectively. This also applies to other commands such as edit and delete.

To improve upon this, a mode feature was implemented so that users can be either in the contact mode or meeting mode and when a command is run it will automatically be translated into the respective contact or meeting command.

### Related Issue(s)
Closes #116 

### Checklist
[Make sure to check the boxes that apply. If an item is not applicable, you can remove it.]

- [x] Unit tests have been added or updated.
- [x] Code has been tested locally and works as expected.
- [x] Documentation has been updated, if necessary.
- [x] All code follows the project's coding standards and style guidelines.


### To-Do
[List any additional tasks or items that need to be completed or addressed before merging this pull request.]

- [x] Add mode command
- [x] Change existing command formats to fit their respective modes
- [x] Add unit tests
- [x] Manual testing of each command
- [x] Update documentation
