### PR TITLE
Implement filter by criteria

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -87,12 +87,13 @@ Notenote provide tools for organizing and categorizing contacts in a systematic 
 
 ### List All Contacts
 
-- **What it does**: Shows all contacts in the list when in the "contacts" mode.
+- **What it does**: Shows all contacts in the list when in the "contacts" mode. All fields after list are optional
+  arguments.
 
-- **Command Format**: `list`
+- **Command Format**: `list -n [NAME] -p [PHONE] -e [EMAIL] -a [ADDRESS] -t [TAG] -c [NOTE]`
 
 - **Expected Outputs**:
-    - Success: List of all contacts.
+    - Success: `%d contacts listed`
     - Failure:
         - If no contacts are available: `No contacts available.`
 
@@ -179,12 +180,13 @@ Notenote provide tools for organizing and categorizing contacts in a systematic 
 
 ### List All Meetings
 
-- **What it does**: Shows a list of all meetings when in the "meetings" mode.
+- **What it does**: Shows a list of all meetings when in the "meetings" mode. All arguments after `list` are optional
+  arguments.
 
-- **Command Format**: `list`
+- **Command Format**: `list -title [TITLE] -time [TIME] -place [PLACE] -desc [DESCRIPTION] -m [NOTE]`
 
 - **Expected Outputs**:
-    - Success: List of all meetings.
+    - Success: `%d Meetings Listed!`
     - Failure:
         - If no meetings are found: `No meetings found`
         - If invalid command format: `Invalid command format`

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,8 @@ title: NoteNote
 
 ![Ui](images/Ui.png)
 
+Download NoteNote [Here](https://github.com/AY2324S1-CS2103-W14-2/tp/releases/tag/v1.3(trial))!
+
 This is a desktop meeting note-taking application that allows users to efficiently record notes for their contact.
 Notenote provide tools for organizing and categorizing contacts in a systematic and easy-to-navigate structure.
 Users interact with the application through a CLI, and it has a GUI created with JavaFX.

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -14,14 +14,15 @@ public class StringUtil {
 
     /**
      * Returns true if the {@code sentence} contains the {@code word}.
-     *   Ignores case, but a full word match is required.
-     *   <br>examples:<pre>
+     * Ignores case, but a full word match is required.
+     * <br>examples:<pre>
      *       containsWordIgnoreCase("ABc def", "abc") == true
      *       containsWordIgnoreCase("ABc def", "DEF") == true
      *       containsWordIgnoreCase("ABc def", "AB") == false //not a full word match
      *       </pre>
+     *
      * @param sentence cannot be null
-     * @param word cannot be null, cannot be empty, must be a single word
+     * @param word     cannot be null, cannot be empty, must be a single word
      */
     public static boolean containsWordIgnoreCase(String sentence, String word) {
         requireNonNull(sentence);
@@ -35,7 +36,7 @@ public class StringUtil {
         String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
 
         return Arrays.stream(wordsInPreppedSentence)
-                .anyMatch(preppedWord::equalsIgnoreCase);
+            .anyMatch(preppedWord::equalsIgnoreCase);
     }
 
     /**
@@ -53,6 +54,7 @@ public class StringUtil {
      * e.g. 1, 2, 3, ..., {@code Integer.MAX_VALUE} <br>
      * Will return false for any other non-null string input
      * e.g. empty string, "-1", "0", "+1", and " 2 " (untrimmed), "3 0" (contains whitespace), "1 a" (contains letters)
+     *
      * @throws NullPointerException if {@code s} is null.
      */
     public static boolean isNonZeroUnsignedInteger(String s) {

--- a/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
@@ -38,16 +38,16 @@ public class EditMeetingCommand extends Command {
     public static final String COMMAND_WORD = "edit";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the meeting identified "
-            + "by the index number used in the displayed meeting list. "
-            + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_TITLE + " TITLE] "
-            + "[" + PREFIX_TIME + " TIME] "
-            + "[" + PREFIX_PLACE + " PLACE] "
-            + "[" + PREFIX_DESCRIPTION + " DESCRIPTION]...\n"
-            + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_PLACE + " Zoom "
-            + PREFIX_DESCRIPTION + " Discuss Project Details";
+        + "by the index number used in the displayed meeting list. "
+        + "Existing values will be overwritten by the input values.\n"
+        + "Parameters: INDEX (must be a positive integer) "
+        + "[" + PREFIX_TITLE + " TITLE] "
+        + "[" + PREFIX_TIME + " TIME] "
+        + "[" + PREFIX_PLACE + " PLACE] "
+        + "[" + PREFIX_DESCRIPTION + " DESCRIPTION]...\n"
+        + "Example: " + COMMAND_WORD + " 1 "
+        + PREFIX_PLACE + " Zoom "
+        + PREFIX_DESCRIPTION + " Discuss Project Details";
 
     public static final String MESSAGE_EDIT_MEETING_SUCCESS = "Edited Meeting: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
@@ -87,7 +87,7 @@ public class EditMeetingCommand extends Command {
         model.setMeeting(meetingToEdit, editedMeeting);
         model.updateFilteredMeetingList(PREDICATE_SHOW_ALL_MEETINGS);
         return new CommandResult(String.format(MESSAGE_EDIT_MEETING_SUCCESS,
-                Messages.formatMeeting(editedMeeting)), null, false, false, null, editedMeeting, ListType.MEETINGS);
+            Messages.formatMeeting(editedMeeting)), "", false, false, null, editedMeeting, ListType.MEETINGS);
     }
 
     /**
@@ -119,15 +119,15 @@ public class EditMeetingCommand extends Command {
 
         EditMeetingCommand otherEditMeetingCommand = (EditMeetingCommand) other;
         return index.equals(otherEditMeetingCommand.index)
-                && editMeetingDescriptor.equals(otherEditMeetingCommand.editMeetingDescriptor);
+            && editMeetingDescriptor.equals(otherEditMeetingCommand.editMeetingDescriptor);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("index", index)
-                .add("editMeetingDescriptor", editMeetingDescriptor)
-                .toString();
+            .add("index", index)
+            .add("editMeetingDescriptor", editMeetingDescriptor)
+            .toString();
     }
 
     /**
@@ -220,8 +220,8 @@ public class EditMeetingCommand extends Command {
 
         public Optional<ArrayList<Contact>> getContacts() {
             return (contacts != null)
-                    ? Optional.of(new ArrayList<Contact>(Collections.unmodifiableList(contacts)))
-                    : Optional.empty();
+                ? Optional.of(new ArrayList<Contact>(Collections.unmodifiableList(contacts)))
+                : Optional.empty();
         }
 
         @Override
@@ -237,19 +237,19 @@ public class EditMeetingCommand extends Command {
 
             EditMeetingDescriptor otherEditMeetingDescriptor = (EditMeetingDescriptor) other;
             return Objects.equals(title, otherEditMeetingDescriptor.title)
-                    && Objects.equals(time, otherEditMeetingDescriptor.time)
-                    && Objects.equals(place, otherEditMeetingDescriptor.place)
-                    && Objects.equals(description, otherEditMeetingDescriptor.description);
+                && Objects.equals(time, otherEditMeetingDescriptor.time)
+                && Objects.equals(place, otherEditMeetingDescriptor.place)
+                && Objects.equals(description, otherEditMeetingDescriptor.description);
         }
 
         @Override
         public String toString() {
             return new ToStringBuilder(this)
-                    .add("title", title)
-                    .add("time", time)
-                    .add("place", place)
-                    .add("description", description)
-                    .toString();
+                .add("title", title)
+                .add("time", time)
+                .add("place", place)
+                .add("description", description)
+                .toString();
         }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListContactCommand.java
@@ -1,10 +1,10 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CONTACTS;
 
 import seedu.address.logic.commands.CommandResult.ListType;
 import seedu.address.model.Model;
+import seedu.address.model.contact.ContactFilterPredicate;
 
 /**
  * Lists all contacts in the address book to the user.
@@ -15,11 +15,17 @@ public class ListContactCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Listed all contacts.";
 
+    private final ContactFilterPredicate predicate;
+
+    public ListContactCommand(ContactFilterPredicate predicate) {
+        this.predicate = predicate;
+    }
+
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredContactList(PREDICATE_SHOW_ALL_CONTACTS);
+        model.updateFilteredContactList(predicate);
         return new CommandResult(MESSAGE_SUCCESS, ListType.CONTACTS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListMeetingCommand.java
@@ -1,10 +1,10 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_MEETINGS;
 
-import seedu.address.logic.commands.CommandResult.ListType;
+import seedu.address.logic.Messages;
 import seedu.address.model.Model;
+import seedu.address.model.meeting.MeetingFilterPredicate;
 
 /**
  * Lists all meetings in the address book to the user.
@@ -15,11 +15,17 @@ public class ListMeetingCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Listed all meetings.";
 
+    private final MeetingFilterPredicate predicate;
+
+    public ListMeetingCommand(MeetingFilterPredicate predicate) {
+        this.predicate = predicate;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredMeetingList(PREDICATE_SHOW_ALL_MEETINGS);
-        return new CommandResult(MESSAGE_SUCCESS, ListType.MEETINGS);
+        model.updateFilteredMeetingList(predicate);
+        return new CommandResult(String.format(Messages.MESSAGE_MEETINGS_LISTED_OVERVIEW,
+            model.getFilteredMeetingList().size()));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
@@ -31,8 +31,9 @@ public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
      */
     public AddMeetingCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_TIME, PREFIX_PLACE,
-                        PREFIX_DESCRIPTION);
+            ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_TIME, PREFIX_PLACE,
+                PREFIX_DESCRIPTION, PREFIX_NOTE_MEETING);
+        boolean test = argMultimap.getPreamble().isEmpty();
         if (!ArgumentMultimap.arePrefixesPresent(argMultimap, PREFIX_TITLE) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingCommand.MESSAGE_USAGE));
         }
@@ -42,7 +43,7 @@ public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
         Time time = ParserUtil.parseTime(argMultimap.getValue(PREFIX_TIME).orElse("03/10/2023 19:00"));
         Place place = ParserUtil.parsePlace(argMultimap.getValue(PREFIX_PLACE).orElse("Zoom"));
         Description description =
-                ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).orElse("No description"));
+            ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).orElse("No description"));
         Set<Note> noteList = ParserUtil.parseNotes(argMultimap.getAllValues(PREFIX_NOTE_MEETING));
         Meeting meeting = new Meeting(title, time, place, description, noteList, new ArrayList<>());
         return new AddMeetingCommand(meeting);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -101,7 +101,7 @@ public class AddressBookParser {
                 return new FindCommandParser().parse(arguments);
 
             case ListContactCommand.COMMAND_WORD:
-                return new ListContactCommand();
+                return new ListContactCommandParser().parse(arguments);
 
             case AddNoteCommand.COMMAND_WORD:
                 return new AddNoteCommandParser().parse(arguments);
@@ -133,7 +133,7 @@ public class AddressBookParser {
                 return new DeleteContactFromMeetingCommandParser().parse(arguments);
 
             case ListMeetingCommand.COMMAND_WORD:
-                return new ListMeetingCommand();
+                return new ListMeetingCommandParser().parse(arguments);
 
             case AddMeetingNoteCommand.COMMAND_WORD:
                 return new AddMeetingNoteCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -13,6 +13,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_TAG = new Prefix("-t");
     public static final Prefix PREFIX_TITLE = new Prefix("-title");
     public static final Prefix PREFIX_TIME = new Prefix("-time");
+    public static final Prefix PREFIX_TIME_START = new Prefix("-ts");
+    public static final Prefix PREFIX_TIME_END = new Prefix("-te");
     public static final Prefix PREFIX_PLACE = new Prefix("-place");
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("-desc");
     public static final Prefix PREFIX_INDEX = new Prefix("-id");

--- a/src/main/java/seedu/address/logic/parser/ListContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListContactCommandParser.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.address.logic.commands.ListContactCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.contact.ContactFilterPredicate;
+
+
+/**
+ * Parses input arguments and creates a new ListMeetingCommand object
+ */
+public class ListContactCommandParser implements Parser<ListContactCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the ListContactCommand
+     * and returns an ListContactCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListContactCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+            ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                PREFIX_ADDRESS, PREFIX_TAG, PREFIX_NOTE_CONTACT);
+        String name = argMultimap.getValue(PREFIX_NAME).orElse("").trim();
+        List<String> nameKeywords = Arrays.asList(name.split("\\s+"));
+        String phone = argMultimap.getValue(PREFIX_PHONE).orElse("");
+        String email = argMultimap.getValue(PREFIX_EMAIL).orElse("").trim();
+        String address = argMultimap.getValue(PREFIX_ADDRESS).orElse("").trim();
+        List<String> addressKeywords = Arrays.asList(address.split("\\s+"));
+        String tag = argMultimap.getValue(PREFIX_TAG).orElse("").trim();
+        List<String> tagKeywords = Arrays.asList(tag.split("\\s+"));
+        String note = argMultimap.getValue(PREFIX_NOTE_CONTACT).orElse("");
+        List<String> noteKeywords = Arrays.asList(note.split("\\s+"));
+        return new ListContactCommand(new ContactFilterPredicate(nameKeywords,
+            phone, email, addressKeywords, tagKeywords, noteKeywords));
+    }
+}
+

--- a/src/main/java/seedu/address/logic/parser/ListMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListMeetingCommandParser.java
@@ -1,0 +1,50 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_MEETING;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PLACE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME_END;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME_START;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
+
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.address.logic.commands.ListMeetingCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.meeting.MeetingFilterPredicate;
+
+/**
+ * Parses input arguments and creates a new ListMeetingCommand object
+ */
+public class ListMeetingCommandParser implements Parser<ListMeetingCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the ListMeetingCommand
+     * and returns an ListMeetingCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListMeetingCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+            ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_TIME_START, PREFIX_TIME_END, PREFIX_PLACE,
+                PREFIX_DESCRIPTION, PREFIX_NOTE_MEETING);
+        String title = argMultimap.getValue(PREFIX_TITLE).orElse("").trim();
+        List<String> titleKeywords = Arrays.asList(title.split("\\s+"));
+        String timeStart = argMultimap.getValue(PREFIX_TIME_START).orElse("");
+        if (!timeStart.equals("")) { // check isValidTime
+            ParserUtil.parseTime(timeStart);
+        }
+        String timeEnd = argMultimap.getValue(PREFIX_TIME_END).orElse("");
+        if (!timeEnd.equals("")) { // check isValidTime
+            ParserUtil.parseTime(timeStart);
+        }
+        String place = argMultimap.getValue(PREFIX_PLACE).orElse("").trim();
+        List<String> placeKeywords = Arrays.asList(place.split("\\s+"));
+        String description = argMultimap.getValue(PREFIX_DESCRIPTION).orElse("").trim();
+        List<String> descriptionKeywords = Arrays.asList(description.split("\\s+"));
+        String note = argMultimap.getValue(PREFIX_NOTE_MEETING).orElse("");
+        List<String> noteKeywords = Arrays.asList(note.split("\\s+"));
+        return new ListMeetingCommand(new MeetingFilterPredicate(titleKeywords,
+            List.of(timeStart, timeEnd), placeKeywords, descriptionKeywords, noteKeywords));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -30,6 +30,7 @@ public class ParserUtil {
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
+     *
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
@@ -200,5 +201,4 @@ public class ParserUtil {
     public static Description parseDescription(String description) {
         return new Description(description);
     }
-
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -142,7 +142,6 @@ public class ModelManager implements Model {
         return addressBook.hasMeeting(meeting);
     }
 
-
     /**
      * Returns an unmodifiable view of the list of {@code Contact} backed by the internal list of
      * {@code versionedAddressBook}
@@ -196,8 +195,8 @@ public class ModelManager implements Model {
 
         ModelManager otherModelManager = (ModelManager) other;
         return addressBook.equals(otherModelManager.addressBook)
-                && userPrefs.equals(otherModelManager.userPrefs)
-                && filteredContacts.equals(otherModelManager.filteredContacts)
-                && filteredMeetings.equals(otherModelManager.filteredMeetings);
+            && userPrefs.equals(otherModelManager.userPrefs)
+            && filteredContacts.equals(otherModelManager.filteredContacts)
+            && filteredMeetings.equals(otherModelManager.filteredMeetings);
     }
 }

--- a/src/main/java/seedu/address/model/contact/Contact.java
+++ b/src/main/java/seedu/address/model/contact/Contact.java
@@ -68,6 +68,20 @@ public class Contact {
         return Collections.unmodifiableSet(tags);
     }
 
+    public String getTagString() {
+        StringBuilder sb = new StringBuilder();
+        Set<Tag> setTags = getTags();
+        for (Tag tags : setTags) {
+            sb.append(tags.toString() + " ");
+        }
+        if (sb.length() > 0) {
+            sb.setLength(sb.length() - 1);
+        } else {
+            return "";
+        }
+        return sb.toString();
+    }
+
     public Set<Note> getNotes() {
         return Collections.unmodifiableSet(notes);
     }
@@ -81,7 +95,7 @@ public class Contact {
         if (sb.length() > 0) {
             sb.setLength(sb.length() - 1);
         } else {
-            return null;
+            return "";
         }
         return sb.toString();
     }
@@ -96,7 +110,7 @@ public class Contact {
         }
 
         return otherContact != null
-                && otherContact.getName().equals(getName());
+            && otherContact.getName().equals(getName());
     }
 
     /**
@@ -116,11 +130,11 @@ public class Contact {
 
         Contact otherContact = (Contact) other;
         return name.equals(otherContact.name)
-                && phone.equals(otherContact.phone)
-                && email.equals(otherContact.email)
-                && address.equals(otherContact.address)
-                && tags.equals(otherContact.tags)
-                && notes.equals(otherContact.notes);
+            && phone.equals(otherContact.phone)
+            && email.equals(otherContact.email)
+            && address.equals(otherContact.address)
+            && tags.equals(otherContact.tags)
+            && notes.equals(otherContact.notes);
     }
 
     @Override
@@ -132,13 +146,13 @@ public class Contact {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("name", name)
-                .add("phone", phone)
-                .add("email", email)
-                .add("address", address)
-                .add("tags", tags)
-                .add("notes", notes)
-                .toString();
+            .add("name", name)
+            .add("phone", phone)
+            .add("email", email)
+            .add("address", address)
+            .add("tags", tags)
+            .add("notes", notes)
+            .toString();
     }
 
 }

--- a/src/main/java/seedu/address/model/contact/ContactFilterPredicate.java
+++ b/src/main/java/seedu/address/model/contact/ContactFilterPredicate.java
@@ -1,0 +1,70 @@
+package seedu.address.model.contact;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Contact}'s {@code all values} matches any of the keywords given.
+ */
+public class ContactFilterPredicate implements Predicate<Contact> {
+    private final List<String> nameKeywords;
+    private final String phoneNumber;
+    private final String emailAddress;
+    private final List<String> addressKeywords;
+    private final List<String> tagKeywords;
+    private final List<String> noteKeywords;
+
+    /**
+     * Contructs the ContactFilterPredicate class
+     */
+    public ContactFilterPredicate(List<String> nameKeywords, String phoneNumber,
+                                  String emailAddress, List<String> addressKeywords,
+                                  List<String> tagKeywords, List<String> noteKeywords) {
+        this.nameKeywords = nameKeywords;
+        this.phoneNumber = phoneNumber;
+        this.emailAddress = emailAddress;
+        this.addressKeywords = addressKeywords;
+        this.tagKeywords = tagKeywords;
+        this.noteKeywords = noteKeywords;
+    }
+
+    @Override
+    public boolean test(Contact contact) {
+        boolean name = (nameKeywords.size() == 1 && nameKeywords.get(0).isEmpty()) || nameKeywords.stream()
+            .anyMatch(keyword -> Arrays.stream(contact.getName().fullName.split("\\s+")).anyMatch(word ->
+                word.equalsIgnoreCase(keyword)));
+        boolean email = emailAddress.equals("") || emailAddress.equals(contact.getEmail().value);
+        boolean phone = phoneNumber.equals("") || phoneNumber.equals(contact.getPhone().value);
+        boolean address = (addressKeywords.size() == 1 && addressKeywords.get(0).isEmpty()) || addressKeywords.stream()
+            .anyMatch(keyword -> Arrays.stream(contact.getAddress().value.split("\\s+")).anyMatch(word ->
+                word.equalsIgnoreCase(keyword)));
+        boolean tag = (tagKeywords.size() == 1 && tagKeywords.get(0).isEmpty())
+            || tagKeywords.stream().anyMatch(keyword -> Arrays.stream(contact.getTagString().split("\\s+"))
+            .anyMatch(word -> word.equalsIgnoreCase(keyword)));
+        boolean note = (noteKeywords.size() == 1 && noteKeywords.get(0).isEmpty())
+            || noteKeywords.stream().anyMatch(keyword -> Arrays.stream(contact.getNoteString().split("\\s+"))
+            .anyMatch(word -> word.equalsIgnoreCase(keyword)));
+        return name && email && phone && address && tag && note;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ContactFilterPredicate)) {
+            return false;
+        }
+
+        ContactFilterPredicate otherContactFilterPredicate = (ContactFilterPredicate) other;
+        return nameKeywords.equals(otherContactFilterPredicate.nameKeywords)
+            && phoneNumber.equals(otherContactFilterPredicate.phoneNumber)
+            && emailAddress.equals(otherContactFilterPredicate.emailAddress)
+            && addressKeywords.equals(otherContactFilterPredicate.addressKeywords)
+            && tagKeywords.equals(otherContactFilterPredicate.tagKeywords)
+            && noteKeywords.equals(otherContactFilterPredicate.noteKeywords);
+    }
+}

--- a/src/main/java/seedu/address/model/contact/Phone.java
+++ b/src/main/java/seedu/address/model/contact/Phone.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Phone {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
+        "Phone numbers should only contain numbers, and it should be at least 3 digits long";
     public static final String VALIDATION_REGEX = "\\d{3,}";
     public final String value;
 

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -83,7 +83,7 @@ public class Meeting {
         if (sb.length() > 0) {
             sb.setLength(sb.length() - 1);
         } else {
-            return null;
+            return "";
         }
         return sb.toString();
     }
@@ -91,13 +91,13 @@ public class Meeting {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("title", title)
-                .add("time", time)
-                .add("place", place)
-                .add("description", description)
-                .add("notes", notes)
-                .add("contacts", contacts)
-                .toString();
+            .add("title", title)
+            .add("time", time)
+            .add("place", place)
+            .add("description", description)
+            .add("notes", notes)
+            .add("contacts", contacts)
+            .toString();
     }
 
     @Override
@@ -113,11 +113,11 @@ public class Meeting {
 
         Meeting otherMeeting = (Meeting) other;
         return title.equals(otherMeeting.title)
-                && time.equals(otherMeeting.time)
-                && place.equals(otherMeeting.place)
-                && description.equals(otherMeeting.description)
-                && notes.equals(otherMeeting.notes)
-                && contacts.equals(otherMeeting.contacts);
+            && time.equals(otherMeeting.time)
+            && place.equals(otherMeeting.place)
+            && description.equals(otherMeeting.description)
+            && notes.equals(otherMeeting.notes)
+            && contacts.equals(otherMeeting.contacts);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/meeting/MeetingFilterPredicate.java
+++ b/src/main/java/seedu/address/model/meeting/MeetingFilterPredicate.java
@@ -1,0 +1,92 @@
+package seedu.address.model.meeting;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+/**
+ * Tests that a {@code Meeting}'s {@code all values} matches any of the keywords given.
+ */
+public class MeetingFilterPredicate implements Predicate<Meeting> {
+    private final List<String> titleKeywords;
+    private final List<String> time;
+    private final List<String> placeKeywords;
+    private final List<String> descriptionKeywords;
+    private final List<String> noteListKeywords;
+
+    /**
+     * Constructor for the MeetinFilterPredicate class
+     */
+    public MeetingFilterPredicate(List<String> titleKeywords, List<String> time,
+                                  List<String> placeKeywords, List<String> descriptionKeywords,
+                                  List<String> noteKeywords) {
+        this.titleKeywords = titleKeywords;
+        this.time = time;
+        this.placeKeywords = placeKeywords;
+        this.descriptionKeywords = descriptionKeywords;
+        this.noteListKeywords = noteKeywords;
+    }
+
+
+    @Override
+    public boolean test(Meeting meeting) {
+        boolean title = (titleKeywords.size() == 1 && titleKeywords.get(0).isEmpty())
+            || titleKeywords.stream().anyMatch(keyword -> Arrays.stream(meeting.getTitle().fullTitle.split("\\s+"))
+            .anyMatch(word -> word.equalsIgnoreCase(keyword)));
+        // writing of stream assisted by chatGPT
+        boolean chrono = false;
+        Time meetingTime = meeting.getTime();
+        Supplier<Boolean> case2 = () -> LocalDateTime.parse(time.get(0), Time.FORMATTER)
+            .isBefore(meetingTime.getValue());
+        Supplier<Boolean> case3 = () -> LocalDateTime.parse(time.get(1), Time.FORMATTER)
+            .isAfter(meetingTime.getValue());
+        Supplier<Boolean> case4 = () -> {
+            LocalDateTime startTime = LocalDateTime.parse(time.get(0), Time.FORMATTER);
+            LocalDateTime endTime = LocalDateTime.parse(time.get(1), Time.FORMATTER);
+            return startTime.isBefore(meetingTime.getValue()) && endTime.isAfter(meetingTime.getValue());
+        };
+        // use of supplier suggested by chatGPT. In original code the logic is nested in if-else statements
+        String timeStart = time.get(0);
+        String timeEnd = time.get(1);
+        if (timeStart.equals("") && timeEnd.equals("")) {
+            chrono = true;
+        } else if (!timeStart.equals("") && timeEnd.equals("")) {
+            chrono = case2.get();
+        } else if (timeStart.equals("") && !timeEnd.equals("")) {
+            chrono = case3.get();
+        } else if (!timeStart.equals("") && !timeEnd.equals("")) {
+            chrono = case4.get();
+        }
+        boolean place = (placeKeywords.size() == 1 && placeKeywords.get(0).isEmpty())
+            || placeKeywords.stream().anyMatch(keyword -> Arrays.stream(meeting.getPlace().fullPlace.split("\\s+"))
+            .anyMatch(word -> word.equalsIgnoreCase(keyword)));
+        boolean description = (descriptionKeywords.size() == 1 && descriptionKeywords.get(0).isEmpty())
+            || descriptionKeywords.stream().anyMatch(keyword -> Arrays.stream(meeting.getDescription().fullDescription
+            .split("\\s+")).anyMatch(word -> word.equalsIgnoreCase(keyword)));
+        boolean note = (noteListKeywords.size() == 1 && noteListKeywords.get(0).isEmpty())
+            || noteListKeywords.stream().anyMatch(keyword -> Arrays.stream(meeting.getNoteString().split("\\s+"))
+            .anyMatch(word -> word.equalsIgnoreCase(keyword)));
+        return title && chrono && place && description && note;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof MeetingFilterPredicate)) {
+            return false;
+        }
+
+        MeetingFilterPredicate otherMeetingFilterPredicate = (MeetingFilterPredicate) other;
+        return titleKeywords.equals(otherMeetingFilterPredicate.titleKeywords)
+            && time.equals(otherMeetingFilterPredicate.time)
+            && placeKeywords.equals(otherMeetingFilterPredicate.placeKeywords)
+            && descriptionKeywords.equals(otherMeetingFilterPredicate.descriptionKeywords)
+            && noteListKeywords.equals(otherMeetingFilterPredicate.noteListKeywords);
+    }
+}

--- a/src/main/java/seedu/address/model/meeting/Time.java
+++ b/src/main/java/seedu/address/model/meeting/Time.java
@@ -14,7 +14,7 @@ import java.time.format.DateTimeParseException;
 public class Time {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Time should match the exact format of dd/MM/yyyy HH:mm";
+        "Time should match the exact format of dd/MM/yyyy HH:mm";
 
     public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
 
@@ -66,6 +66,10 @@ public class Time {
     public static Time fromString(String timeStr) {
         LocalDateTime parsedDateTime = LocalDateTime.parse(timeStr, FORMATTER);
         return new Time(parsedDateTime);
+    }
+
+    public LocalDateTime getValue() {
+        return value;
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/ListContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListContactCommandTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.CommandResult.ListType;
+import seedu.address.logic.parser.ListContactCommandParser;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -28,17 +30,19 @@ public class ListContactCommandTest {
     }
 
     @Test
-    public void execute_listIsNotFiltered_showsSameList() {
+    public void execute_listIsNotFiltered_showsSameList() throws ParseException {
         CommandResult expectedCommandResult = new CommandResult(ListContactCommand.MESSAGE_SUCCESS,
-                ListType.CONTACTS);
-        assertCommandSuccess(new ListContactCommand(), model, expectedCommandResult, expectedModel);
+            ListType.CONTACTS);
+        ListContactCommand actualCommand = new ListContactCommandParser().parse("list");
+        assertCommandSuccess(actualCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test
-    public void execute_listIsFiltered_showsEverything() {
+    public void execute_listIsFiltered_showsEverything() throws ParseException {
         CommandResult expectedCommandResult = new CommandResult(ListContactCommand.MESSAGE_SUCCESS,
-                ListType.CONTACTS);
+            ListType.CONTACTS);
+        ListContactCommand actualCommand = new ListContactCommandParser().parse("list");
         showContactAtIndex(model, INDEX_FIRST);
-        assertCommandSuccess(new ListContactCommand(), model, expectedCommandResult, expectedModel);
+        assertCommandSuccess(actualCommand, model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListMeetingCommandTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.Messages.MESSAGE_MEETINGS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showMeetingAtIndex;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalMeetingsAddressBook;
@@ -9,6 +10,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.CommandResult.ListType;
+import seedu.address.logic.parser.ListMeetingCommandParser;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -28,17 +31,19 @@ public class ListMeetingCommandTest {
     }
 
     @Test
-    public void execute_listIsNotFiltered_showsSameList() {
-        CommandResult expectedCommandResult = new CommandResult(ListMeetingCommand.MESSAGE_SUCCESS,
-                ListType.MEETINGS);
-        assertCommandSuccess(new ListMeetingCommand(), model, expectedCommandResult, expectedModel);
+    public void execute_listIsNotFiltered_showsSameList() throws ParseException {
+        CommandResult expectedCommandResult = new CommandResult(String.format(MESSAGE_MEETINGS_LISTED_OVERVIEW, 4),
+            ListType.NONE);
+        ListMeetingCommand actualCommand = new ListMeetingCommandParser().parse("list");
+        assertCommandSuccess(actualCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test
-    public void execute_listIsFiltered_showsEverything() {
-        CommandResult expectedCommandResult = new CommandResult(ListMeetingCommand.MESSAGE_SUCCESS,
-                ListType.MEETINGS);
+    public void execute_listIsFiltered_showsEverything() throws ParseException {
+        CommandResult expectedCommandResult = new CommandResult(String.format(MESSAGE_MEETINGS_LISTED_OVERVIEW, 4),
+            ListType.NONE);
+        ListMeetingCommand actualCommand = new ListMeetingCommandParser().parse("list");
         showMeetingAtIndex(model, INDEX_FIRST);
-        assertCommandSuccess(new ListMeetingCommand(), model, expectedCommandResult, expectedModel);
+        assertCommandSuccess(actualCommand, model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/testutil/MeetingBuilder.java
+++ b/src/test/java/seedu/address/testutil/MeetingBuilder.java
@@ -45,8 +45,8 @@ public class MeetingBuilder {
         time = new Time(DEFAULT_TIME);
         place = new Place(DEFAULT_PLACE);
         description = new Description(DEFAULT_DESCRIPTION);
-        notes = new HashSet<>();
-        contacts = new ArrayList<>();
+        notes = new HashSet<Note>();
+        contacts = new ArrayList<Contact>();
     }
 
     /**


### PR DESCRIPTION
Users have to go through the entire contact and meeting list to find the entries they want. The find function of find only covers contact name.

Let's,
modify the list function such that user can enter
attributes of the contact or meeting such as name, title, address, place and so on, to list only the contact or meetings that matches these attributes.

This will give user greater convenience in finding the entry that they are looking for.

The filter keywords are case insensitive, order of the keywords does not matter and entries matching at least one keyword will be returned.

### Related Issue(s)
[https://github.com/AY2324S1-CS2103-W14-2/tp/issues/114]

### Checklist

- [X] Unit tests have been updated.
- [X] Code has been tested locally and works as expected.
- [X] Dependencies have been checked and updated, if necessary.
- [X] All code follows the project's coding standards and style guidelines.


### To-Do

- [X] Implement list with filters on all meeting attributes
- [X] Implement list with filters on all contact attributes

Fixes #114 
