### PR TITLE
Change Text Field to Reset

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -14,7 +14,7 @@ import seedu.address.model.meeting.Meeting;
  */
 public class Messages {
 
-    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command: %1$s";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX = "The contact index provided is invalid";
     public static final String MESSAGE_INVALID_MEETING_DISPLAYED_INDEX = "The meeting index provided is invalid";

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -144,6 +144,6 @@ public class AddressBookParser {
         }
 
         logger.finer("This user input caused a ParseException: " + userInput);
-        throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+        throw new ParseException(String.format(MESSAGE_UNKNOWN_COMMAND, userInput));
     }
 }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -57,14 +57,14 @@ public class CommandBox extends UiPart<Region> {
         commandHistory.add(commandText);
 
         currentHistoryPointer = commandHistory.size();
-        hasStartedHistoryNavigation = false;
 
         try {
             commandExecutor.execute(commandText);
-            commandTextField.setText("");
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
         }
+
+        commandTextField.setText("");
     }
 
     /**

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -56,7 +56,7 @@ public class LogicManagerTest {
     @Test
     public void execute_invalidCommandFormat_throwsParseException() {
         String invalidCommand = "uicfhmowqewca";
-        assertParseException(invalidCommand, MESSAGE_UNKNOWN_COMMAND);
+        assertParseException(invalidCommand, String.format(MESSAGE_UNKNOWN_COMMAND, invalidCommand));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -171,7 +171,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand", model));
+        assertThrows(ParseException.class, String.format(MESSAGE_UNKNOWN_COMMAND, "unknownCommand"), ()
+            -> parser.parseCommand("unknownCommand", model));
     }
 
     @Test


### PR DESCRIPTION
### Description
Small change to reset text field when an invalid command is entered.
Also reflects the unknown command entered when entered.

### Related Issue(s)
[Use up arrow key to view previous command](https://github.com/AY2324S1-CS2103-W14-2/tp/issues/118)

### Checklist
[Make sure to check the boxes that apply. If an item is not applicable, you can remove it.]

- [X] Unit tests have been added or updated.
- [X] Code has been tested locally and works as expected.
- [ ] Documentation has been updated, if necessary.
- [X] Dependencies have been checked and updated, if necessary.
- [X] All code follows the project's coding standards and style guidelines.
