### PR TITLE
Add support for deleting notes

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -384,7 +384,7 @@ giving users the ability to edit previous notes, but that is outside the scope o
 ### Implementation (Add Notes)
 
 A new `Note` class is created, which stores the contents of the note as a string. The `Contact`/`Meeting` model is then updated
-to include a new `notes` attribute of type `ArrayList<Note>`.
+to include a new `notes` attribute of type `HashSet<Note>`.
 
 To distinguish between adding notes to contacts and meetings, 2 separate Command classes are created, namely 
 `AddNoteCommand` (for contacts) and `AddMeetingNoteCommand` (for meetings). These classes will then call 
@@ -398,6 +398,20 @@ and append the additional note.
 Then, a new `Contact`/`Meeting` will be created with identical attributes as the original, with the exception of the
 updated `notes` list. The model is then updated with this new `Contact`/`Meeting`, and the filtered list is
 updated as well.
+
+### Implementation (Delete Notes)
+
+Within each `Note` class, there is a `noteID` field which is stored as an `int`. `noteID` is assigned based on the total number
+of notes in the system i.e. if there are 5 notes in the app now, the next note will have a `noteID` of 6. In this manner, each
+Note thus has a unique `noteID`.
+
+Once again, there are separate commands for deleting notes from contacts and from meetings. The relationship between the Command
+and respective Parser classes is similar to the one described for adding Notes.
+
+In terms of execution, a user will pass the `noteID` of the Note to be deleted as an argument. Notenote will then iterate through
+the HashSet, and when a Note's `noteID` matches the one specified by the user, will remove the Note from the HashSet accordingly.
+
+The `Contact`/`Meeting` model will then be updated with the new HashSet of Notes.
 
 ### Design Considerations
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -289,8 +289,8 @@ Notenote provide tools for organizing and categorizing contacts in a systematic 
     - For Meetings when in "Meetings" mode: `add note -id MEETING_ID_or_MEETING_NAME -m NOTES`
 
 - **Examples**:
-    - `add note -id 5 -note Has a dog named Benny`
-    - `add note -id Project Discussion -note Agenda: Discuss Q2 results`
+    - `add note -id 5 -c Has a dog named Benny`
+    - `add note -id Project Discussion -m Agenda: Discuss Q2 results`
 
 - **Acceptable Values**:
     - CONTACT_ID: Non-negative integer.
@@ -315,19 +315,19 @@ Notenote provide tools for organizing and categorizing contacts in a systematic 
 - **What it does**: Removes specified notes from a contact or meeting.
 
 - **Command Format**:
-    - For Contacts when in "contacts" mode: `delete note -id CONTACT_ID_or_CONTACT_NAME -index NOTE_INDEX`
-    - For Meetings when in "Meetings" mode: `delete note -id MEETING_ID_or_MEETING_NAME -index NOTE_INDEX`
+    - For Contacts when in "contacts" mode: `delete note -id CONTACT_ID_or_CONTACT_NAME -noteid NOTE_ID`
+    - For Meetings when in "Meetings" mode: `delete note -id MEETING_ID_or_MEETING_NAME -noteid NOTE_ID
 
 - **Examples**:
-    - `delete note -id 5 -index 2`
-    - `delete note -id Project Discussion -index 1`
+    - `delete note -id 5 -noteid 2`
+    - `delete note -id Project Discussion -noteid 1`
 
 - **Acceptable Values**:
     - CONTACT_ID: Non-negative integer.
     - CONTACT_NAME: String, at least 2 characters long. Not case sensitive.
     - MEETING_ID: Non-negative integer.
     - MEETING_NAME: String, at least 2 characters long. Not case sensitive.
-    - NOTE_INDEX: Non-negative integer. Index of the note as displayed in the notes list of a contact or meeting.
+    - NOTE_ID: Non-negative integer. Index of the note as displayed in the notes list of a contact or meeting, and is preceded by a "#".
 
 - **Expected Outputs**:
     - Success:

--- a/src/main/java/seedu/address/logic/commands/DeleteMeetingNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteMeetingNoteCommand.java
@@ -1,0 +1,116 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.*;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.model.note.Note;
+import seedu.address.ui.AppState;
+
+/**
+ * Deletes a note of an existing meeting in the address book.
+ */
+public class DeleteMeetingNoteCommand extends Command {
+
+    public static final String COMMAND_WORD = "delete note";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the note of the meeting identified "
+            + "by the index number used in the last meeting listing. "
+            + "Parameters: " + PREFIX_INDEX + " (must be a positive integer) "
+            + PREFIX_NOTE_MEETING + " [NOTE]\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_INDEX + " 1 "
+            + PREFIX_NOTE_ID + " 1.";
+
+    public static final String MESSAGE_ADD_NOTE_SUCCESS = "Added note to Meeting: %1$s";
+    public static final String MESSAGE_DELETE_NOTE_SUCCESS = "Removed note from Meeting: %1$s";
+
+    private final Index index;
+    private final int noteID;
+
+    /**
+     * @param index of the person in the filtered person list to edit the note
+     * @param noteID of the note to be deleted
+     */
+    public DeleteMeetingNoteCommand(Index index, int noteID) {
+        requireAllNonNull(index, noteID);
+
+        this.index = index;
+        this.noteID = noteID;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        List<Meeting> lastShownList = model.getFilteredMeetingList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+        }
+
+        Meeting meetingToEdit = lastShownList.get(index.getZeroBased());
+
+        Set<Note> mutableNotesList = new HashSet<>(meetingToEdit.getNotes());
+        Iterator<Note> iterator = mutableNotesList.iterator();
+        while (iterator.hasNext()) {
+            Note note = iterator.next();
+            if (note.getNoteID() == noteID) {
+                iterator.remove();
+            }
+        }
+
+        HashSet<Note> newNoteSet = new HashSet<>();
+        iterator = mutableNotesList.iterator();
+        while (iterator.hasNext()) {
+            newNoteSet.add(iterator.next());
+        }
+
+        Meeting editedMeeting = new Meeting(
+                meetingToEdit.getTitle(), meetingToEdit.getTime(), meetingToEdit.getPlace(),
+                meetingToEdit.getDescription(), newNoteSet, meetingToEdit.getContacts());
+
+        model.setMeeting(meetingToEdit, editedMeeting);
+        model.updateFilteredMeetingList(Model.PREDICATE_SHOW_ALL_MEETINGS);
+
+        AppState appState = AppState.getInstance();
+        appState.setMeeting(editedMeeting);
+
+        return new CommandResult(generateSuccessMessage(editedMeeting), false, false);
+    }
+
+    /**
+     * Generates a command execution success message based on whether
+     * the note is added to or removed from
+     * {@code meetingToEdit}.
+     */
+    private String generateSuccessMessage(Meeting meetingToEdit) {
+        String message = MESSAGE_DELETE_NOTE_SUCCESS;
+        return String.format(message, meetingToEdit);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteMeetingNoteCommand)) {
+            return false;
+        }
+
+        // state check
+        DeleteMeetingNoteCommand e = (DeleteMeetingNoteCommand) other;
+        return index.equals(e.index)
+                && noteID == e.noteID;
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/DeleteMeetingNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteMeetingNoteCommand.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_MEETING;
 
 import java.util.HashSet;
 import java.util.Iterator;

--- a/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
 
 import java.util.HashSet;
 import java.util.Iterator;
@@ -27,7 +29,7 @@ public class DeleteNoteCommand extends Command {
             + ": Deletes the note of the meeting identified "
             + "by the index number used in the last meeting listing. "
             + "Parameters: " + PREFIX_INDEX + " (must be a positive integer) "
-            + PREFIX_NOTE_MEETING + " [NOTE]\n"
+            + PREFIX_NOTE_CONTACT + " [NOTE]\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_INDEX + " 1 "
             + PREFIX_NOTE_ID + " 1.";
 

--- a/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
@@ -12,7 +12,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.meeting.Meeting;
+import seedu.address.model.contact.Contact;
 import seedu.address.model.note.Note;
 import seedu.address.ui.AppState;
 
@@ -50,15 +50,15 @@ public class DeleteNoteCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        List<Meeting> lastShownList = model.getFilteredMeetingList();
+        List<Contact> lastShownList = model.getFilteredContactList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
         }
 
-        Meeting meetingToEdit = lastShownList.get(index.getZeroBased());
+        Contact contactToEdit = lastShownList.get(index.getZeroBased());
 
-        Set<Note> mutableNotesList = new HashSet<>(meetingToEdit.getNotes());
+        Set<Note> mutableNotesList = new HashSet<>(contactToEdit.getNotes());
         Iterator<Note> iterator = mutableNotesList.iterator();
         while (iterator.hasNext()) {
             Note note = iterator.next();
@@ -73,17 +73,17 @@ public class DeleteNoteCommand extends Command {
             newNoteSet.add(iterator.next());
         }
 
-        Meeting editedMeeting = new Meeting(
-                meetingToEdit.getTitle(), meetingToEdit.getTime(), meetingToEdit.getPlace(),
-                meetingToEdit.getDescription(), newNoteSet, meetingToEdit.getContacts());
+        Contact editedContact = new Contact(
+                contactToEdit.getName(), contactToEdit.getPhone(), contactToEdit.getEmail(),
+                contactToEdit.getAddress(), contactToEdit.getTags(), newNoteSet);
 
-        model.setMeeting(meetingToEdit, editedMeeting);
-        model.updateFilteredMeetingList(Model.PREDICATE_SHOW_ALL_MEETINGS);
+        model.setContact(contactToEdit, editedContact);
+        model.updateFilteredContactList(Model.PREDICATE_SHOW_ALL_CONTACTS);
 
         AppState appState = AppState.getInstance();
-        appState.setMeeting(editedMeeting);
+        appState.setContact(editedContact);
 
-        return new CommandResult(generateSuccessMessage(editedMeeting), false, false);
+        return new CommandResult(generateSuccessMessage(editedContact), false, false);
     }
 
     /**
@@ -91,9 +91,9 @@ public class DeleteNoteCommand extends Command {
      * the note is added to or removed from
      * {@code meetingToEdit}.
      */
-    private String generateSuccessMessage(Meeting meetingToEdit) {
+    private String generateSuccessMessage(Contact contactToEdit) {
         String message = MESSAGE_DELETE_NOTE_SUCCESS;
-        return String.format(message, meetingToEdit);
+        return String.format(message, contactToEdit);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
@@ -1,0 +1,116 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.*;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.model.note.Note;
+import seedu.address.ui.AppState;
+
+/**
+ * Deletes a note of an existing Contact in the address book.
+ */
+public class DeleteNoteCommand extends Command {
+
+    public static final String COMMAND_WORD = "delete note";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the note of the meeting identified "
+            + "by the index number used in the last meeting listing. "
+            + "Parameters: " + PREFIX_INDEX + " (must be a positive integer) "
+            + PREFIX_NOTE_MEETING + " [NOTE]\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_INDEX + " 1 "
+            + PREFIX_NOTE_ID + " 1.";
+
+    public static final String MESSAGE_ADD_NOTE_SUCCESS = "Added note to Contact: %1$s";
+    public static final String MESSAGE_DELETE_NOTE_SUCCESS = "Removed note from Contact: %1$s";
+
+    private final Index index;
+    private final int noteID;
+
+    /**
+     * @param index of the person in the filtered person list to edit the note
+     * @param noteID of the note to be deleted
+     */
+    public DeleteNoteCommand(Index index, int noteID) {
+        requireAllNonNull(index, noteID);
+
+        this.index = index;
+        this.noteID = noteID;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        List<Meeting> lastShownList = model.getFilteredMeetingList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+        }
+
+        Meeting meetingToEdit = lastShownList.get(index.getZeroBased());
+
+        Set<Note> mutableNotesList = new HashSet<>(meetingToEdit.getNotes());
+        Iterator<Note> iterator = mutableNotesList.iterator();
+        while (iterator.hasNext()) {
+            Note note = iterator.next();
+            if (note.getNoteID() == noteID) {
+                iterator.remove();
+            }
+        }
+
+        HashSet<Note> newNoteSet = new HashSet<>();
+        iterator = mutableNotesList.iterator();
+        while (iterator.hasNext()) {
+            newNoteSet.add(iterator.next());
+        }
+
+        Meeting editedMeeting = new Meeting(
+                meetingToEdit.getTitle(), meetingToEdit.getTime(), meetingToEdit.getPlace(),
+                meetingToEdit.getDescription(), newNoteSet, meetingToEdit.getContacts());
+
+        model.setMeeting(meetingToEdit, editedMeeting);
+        model.updateFilteredMeetingList(Model.PREDICATE_SHOW_ALL_MEETINGS);
+
+        AppState appState = AppState.getInstance();
+        appState.setMeeting(editedMeeting);
+
+        return new CommandResult(generateSuccessMessage(editedMeeting), false, false);
+    }
+
+    /**
+     * Generates a command execution success message based on whether
+     * the note is added to or removed from
+     * {@code meetingToEdit}.
+     */
+    private String generateSuccessMessage(Meeting meetingToEdit) {
+        String message = MESSAGE_DELETE_NOTE_SUCCESS;
+        return String.format(message, meetingToEdit);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteNoteCommand)) {
+            return false;
+        }
+
+        // state check
+        DeleteNoteCommand e = (DeleteNoteCommand) other;
+        return index.equals(e.index)
+                && noteID == e.noteID;
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,8 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteContactCommand;
 import seedu.address.logic.commands.DeleteContactFromMeetingCommand;
 import seedu.address.logic.commands.DeleteMeetingCommand;
+import seedu.address.logic.commands.DeleteMeetingNoteCommand;
+import seedu.address.logic.commands.DeleteNoteCommand;
 import seedu.address.logic.commands.EditContactCommand;
 import seedu.address.logic.commands.EditMeetingCommand;
 import seedu.address.logic.commands.ExitCommand;
@@ -107,6 +109,9 @@ public class AddressBookParser {
             case AddNoteCommand.COMMAND_WORD:
                 return new AddNoteCommandParser().parse(arguments);
 
+            case DeleteNoteCommand.COMMAND_WORD:
+                return new DeleteNoteCommandParser().parse(arguments);
+
             default:
                 break;
             }
@@ -138,6 +143,9 @@ public class AddressBookParser {
 
             case AddMeetingNoteCommand.COMMAND_WORD:
                 return new AddMeetingNoteCommandParser().parse(arguments);
+
+            case DeleteMeetingNoteCommand.COMMAND_WORD:
+                return new DeleteMeetingNoteCommandParser().parse(arguments);
 
             default:
                 break;

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -22,4 +22,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_NOTE = new Prefix("-z");
     public static final Prefix PREFIX_NOTE_CONTACT = new Prefix("-c");
     public static final Prefix PREFIX_NOTE_MEETING = new Prefix("-m");
+    public static final Prefix PREFIX_NOTE_ID = new Prefix("-noteid");
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteMeetingNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteMeetingNoteCommandParser.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.parser;
+
+import static java.lang.Integer.parseInt;
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteMeetingNoteCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new {@code DeleteMeetingNoteCommand} object
+ */
+public class DeleteMeetingNoteCommandParser implements Parser<DeleteMeetingNoteCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code DeleteMeetingNoteCommand}
+     * and returns a {@code AddMeetingNoteCommand} object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteMeetingNoteCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_INDEX, PREFIX_NOTE_ID);
+
+        Index index;
+        try {
+            index = Index.fromOneBased(parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
+        } catch (Exception e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    DeleteMeetingNoteCommand.MESSAGE_USAGE), e);
+        }
+
+        int noteID = parseInt(argMultimap.getValue(PREFIX_NOTE_ID).orElse(""));
+
+        return new DeleteMeetingNoteCommand(index, noteID);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/DeleteNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteNoteCommandParser.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.parser;
+
+import static java.lang.Integer.parseInt;
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteNoteCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new {@code DeleteMeetingNoteCommand} object
+ */
+public class DeleteNoteCommandParser implements Parser<DeleteNoteCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code DeleteMeetingNoteCommand}
+     * and returns a {@code AddMeetingNoteCommand} object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteNoteCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_INDEX, PREFIX_NOTE_ID);
+
+        Index index;
+        try {
+            index = Index.fromOneBased(parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
+        } catch (Exception e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    DeleteNoteCommand.MESSAGE_USAGE), e);
+        }
+
+        int noteID = parseInt(argMultimap.getValue(PREFIX_NOTE_ID).orElse(""));
+
+        return new DeleteNoteCommand(index, noteID);
+    }
+}

--- a/src/main/java/seedu/address/model/contact/Contact.java
+++ b/src/main/java/seedu/address/model/contact/Contact.java
@@ -90,7 +90,7 @@ public class Contact {
         StringBuilder sb = new StringBuilder();
         Set<Note> setNotes = getNotes();
         for (Note notes : setNotes) {
-            sb.append(notes.toString() + "\n");
+            sb.append(notes.toString() + " #" + notes.getNoteID() + "\n");
         }
         if (sb.length() > 0) {
             sb.setLength(sb.length() - 1);

--- a/src/main/java/seedu/address/model/note/Note.java
+++ b/src/main/java/seedu/address/model/note/Note.java
@@ -7,7 +7,9 @@ import static java.util.Objects.requireNonNull;
  * Guarantees: immutable; is always valid
  */
 public class Note {
+    public static int ID = 1;
     public final String note;
+    public final int noteID;
 
     /**
      * Constructs a {@code Note}.
@@ -17,11 +19,15 @@ public class Note {
     public Note(String note) {
         requireNonNull(note);
         this.note = note;
+        this.noteID = ID++;
     }
 
+    public int getNoteID() {
+        return noteID;
+    }
     @Override
     public String toString() {
-        return note;
+        return note + " #" + noteID;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/note/Note.java
+++ b/src/main/java/seedu/address/model/note/Note.java
@@ -27,7 +27,7 @@ public class Note {
     }
     @Override
     public String toString() {
-        return note + " #" + noteID;
+        return note;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/note/Note.java
+++ b/src/main/java/seedu/address/model/note/Note.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
  * Guarantees: immutable; is always valid
  */
 public class Note {
-    public static int ID = 1;
+    private static int noteCount = 1;
     public final String note;
     public final int noteID;
 
@@ -19,7 +19,7 @@ public class Note {
     public Note(String note) {
         requireNonNull(note);
         this.note = note;
-        this.noteID = ID++;
+        this.noteID = noteCount++;
     }
 
     public int getNoteID() {

--- a/src/test/java/seedu/address/logic/commands/AddMeetingNoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddMeetingNoteCommandTest.java
@@ -1,0 +1,137 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.model.note.Note;
+import seedu.address.testutil.MeetingBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for AddMeetingNoteCommand.
+ */
+public class AddMeetingNoteCommandTest {
+
+    private static final String NOTE_STUB = "Some note";
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_addNoteUnfilteredList_success() {
+        Meeting firstMeeting = model.getFilteredMeetingList().get(INDEX_SECOND.getZeroBased());
+        Meeting editedMeeting = new MeetingBuilder(firstMeeting).withNotes(NOTE_STUB).build();
+
+        AddMeetingNoteCommand addMeetingNoteCommand = new AddMeetingNoteCommand(INDEX_SECOND, new Note(NOTE_STUB));
+
+        String expectedMessage = String.format(AddMeetingNoteCommand.MESSAGE_ADD_NOTE_SUCCESS, editedMeeting);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setMeeting(firstMeeting, editedMeeting);
+
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false);
+
+        assertCommandSuccess(addMeetingNoteCommand, model, expectedCommandResult, expectedModel);
+    }
+
+    // Delete functionality has not been implemented yet
+    //    @Test
+    //    public void execute_deleteNoteUnfilteredList_success() {
+    //        Contact firstPerson = model.getFilteredContactList().get(INDEX_FIRST.getZeroBased());
+    //        Contact editedPerson = new ContactBuilder(firstPerson).withNotes("").build();
+    //
+    //        AddNoteCommand addNoteCommand = new AddNoteCommand(INDEX_FIRST,
+    //                new Note(editedPerson.getNotes().toString()));
+    //
+    //        String expectedMessage = String.format(AddNoteCommand.MESSAGE_ADD_NOTE_SUCCESS, editedPerson);
+    //
+    //        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+    //        expectedModel.setContact(firstPerson, editedPerson);
+    //
+    //        assertCommandSuccess(addNoteCommand, model, expectedMessage, expectedModel);
+    //    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showMeetingAtIndex(model, INDEX_FIRST);
+
+        Meeting firstMeeting = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
+        Meeting editedMeeting = new MeetingBuilder(model.getFilteredMeetingList()
+                .get(INDEX_FIRST.getZeroBased()))
+                .withNotes(NOTE_STUB).build();
+
+        AddMeetingNoteCommand addMeetingNoteCommand = new AddMeetingNoteCommand(INDEX_FIRST, new Note(NOTE_STUB));
+
+        String expectedMessage = String.format(AddMeetingNoteCommand.MESSAGE_ADD_NOTE_SUCCESS, editedMeeting);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setMeeting(firstMeeting, editedMeeting);
+
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false);
+
+        assertCommandSuccess(addMeetingNoteCommand, model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidMeetingIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredMeetingList().size() + 1);
+        AddMeetingNoteCommand addMeetingNoteCommand = new AddMeetingNoteCommand(outOfBoundIndex, new Note(VALID_NOTE_BOB));
+
+        assertCommandFailure(addMeetingNoteCommand, model, Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of address book
+     */
+    @Test
+    public void execute_invalidMeetingIndexFilteredList_failure() {
+        showMeetingAtIndex(model, INDEX_FIRST);
+        Index outOfBoundIndex = INDEX_SECOND;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getMeetingList().size());
+
+        AddMeetingNoteCommand addMeetingNoteCommand = new AddMeetingNoteCommand(outOfBoundIndex, new Note(VALID_NOTE_BOB));
+
+        assertCommandFailure(addMeetingNoteCommand, model, Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final AddMeetingNoteCommand standardCommand = new AddMeetingNoteCommand(INDEX_FIRST,
+                new Note(VALID_NOTE_AMY));
+
+        // same values -> returns true
+        AddMeetingNoteCommand commandWithSameValues = new AddMeetingNoteCommand(INDEX_FIRST,
+                new Note(VALID_NOTE_AMY));
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new AddMeetingNoteCommand(INDEX_SECOND,
+                new Note(VALID_NOTE_AMY))));
+
+        // different note -> returns false
+        assertFalse(standardCommand.equals(new AddMeetingNoteCommand(INDEX_FIRST,
+                new Note(VALID_NOTE_BOB))));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/AddMeetingNoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddMeetingNoteCommandTest.java
@@ -2,7 +2,11 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NOTE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NOTE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showMeetingAtIndex;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
@@ -86,7 +90,8 @@ public class AddMeetingNoteCommandTest {
     @Test
     public void execute_invalidMeetingIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredMeetingList().size() + 1);
-        AddMeetingNoteCommand addMeetingNoteCommand = new AddMeetingNoteCommand(outOfBoundIndex, new Note(VALID_NOTE_BOB));
+        AddMeetingNoteCommand addMeetingNoteCommand = new AddMeetingNoteCommand(outOfBoundIndex,
+                new Note(VALID_NOTE_BOB));
 
         assertCommandFailure(addMeetingNoteCommand, model, Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
     }
@@ -102,7 +107,8 @@ public class AddMeetingNoteCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getMeetingList().size());
 
-        AddMeetingNoteCommand addMeetingNoteCommand = new AddMeetingNoteCommand(outOfBoundIndex, new Note(VALID_NOTE_BOB));
+        AddMeetingNoteCommand addMeetingNoteCommand = new AddMeetingNoteCommand(outOfBoundIndex,
+                new Note(VALID_NOTE_BOB));
 
         assertCommandFailure(addMeetingNoteCommand, model, Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
     }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -34,6 +34,8 @@ import seedu.address.testutil.EditMeetingDescriptorBuilder;
  */
 public class CommandTestUtil {
 
+    public static final int VALID_CONTACT_NOTEID = 4;
+    public static final int VALID_MEETING_NOTEID = 11;
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";
@@ -44,6 +46,7 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_NOTE_AMY = "Likes apples";
     public static final String VALID_NOTE_BOB = "Knee injury";
+    public static final String VALID_NOTE_BENSON = "Hates tiramisu";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 

--- a/src/test/java/seedu/address/logic/commands/DeleteMeetingNoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteMeetingNoteCommandTest.java
@@ -2,7 +2,10 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MEETING_NOTEID;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showMeetingAtIndex;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
@@ -32,7 +35,8 @@ public class DeleteMeetingNoteCommandTest {
         Meeting firstMeeting = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
         Meeting editedMeeting = new MeetingBuilder(firstMeeting).withNotes().build();
 
-        DeleteMeetingNoteCommand deleteMeetingNoteCommand = new DeleteMeetingNoteCommand(INDEX_FIRST, VALID_MEETING_NOTEID);
+        DeleteMeetingNoteCommand deleteMeetingNoteCommand = new DeleteMeetingNoteCommand(INDEX_FIRST,
+                VALID_MEETING_NOTEID);
 
         String expectedMessage = String.format(DeleteMeetingNoteCommand.MESSAGE_DELETE_NOTE_SUCCESS, editedMeeting);
 
@@ -53,7 +57,8 @@ public class DeleteMeetingNoteCommandTest {
                 .get(INDEX_FIRST.getZeroBased()))
                 .withNotes().build();
 
-        DeleteMeetingNoteCommand deleteMeetingNoteCommand = new DeleteMeetingNoteCommand(INDEX_FIRST, VALID_MEETING_NOTEID);
+        DeleteMeetingNoteCommand deleteMeetingNoteCommand = new DeleteMeetingNoteCommand(INDEX_FIRST,
+                VALID_MEETING_NOTEID);
 
         String expectedMessage = String.format(DeleteMeetingNoteCommand.MESSAGE_DELETE_NOTE_SUCCESS, editedMeeting);
 
@@ -68,7 +73,8 @@ public class DeleteMeetingNoteCommandTest {
     @Test
     public void execute_invalidMeetingIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredMeetingList().size() + 1);
-        DeleteMeetingNoteCommand deleteMeetingNoteCommand = new DeleteMeetingNoteCommand(outOfBoundIndex, VALID_MEETING_NOTEID);
+        DeleteMeetingNoteCommand deleteMeetingNoteCommand = new DeleteMeetingNoteCommand(outOfBoundIndex,
+                VALID_MEETING_NOTEID);
 
         assertCommandFailure(deleteMeetingNoteCommand, model, Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
     }
@@ -84,7 +90,8 @@ public class DeleteMeetingNoteCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getMeetingList().size());
 
-        DeleteMeetingNoteCommand deleteMeetingNoteCommand = new DeleteMeetingNoteCommand(outOfBoundIndex, VALID_MEETING_NOTEID);
+        DeleteMeetingNoteCommand deleteMeetingNoteCommand = new DeleteMeetingNoteCommand(outOfBoundIndex,
+                VALID_MEETING_NOTEID);
 
         assertCommandFailure(deleteMeetingNoteCommand, model, Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteMeetingNoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteMeetingNoteCommandTest.java
@@ -1,0 +1,119 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.testutil.MeetingBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for DeleteMeetingNoteCommand.
+ */
+public class DeleteMeetingNoteCommandTest {
+
+    private static final String NOTE_STUB = "Some note";
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_deleteNoteUnfilteredList_success() {
+        Meeting firstMeeting = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
+        Meeting editedMeeting = new MeetingBuilder(firstMeeting).withNotes().build();
+
+        DeleteMeetingNoteCommand deleteMeetingNoteCommand = new DeleteMeetingNoteCommand(INDEX_FIRST, VALID_MEETING_NOTEID);
+
+        String expectedMessage = String.format(DeleteMeetingNoteCommand.MESSAGE_DELETE_NOTE_SUCCESS, editedMeeting);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setMeeting(firstMeeting, editedMeeting);
+
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false);
+
+        assertCommandSuccess(deleteMeetingNoteCommand, model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showMeetingAtIndex(model, INDEX_FIRST);
+
+        Meeting firstMeeting = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
+        Meeting editedMeeting = new MeetingBuilder(model.getFilteredMeetingList()
+                .get(INDEX_FIRST.getZeroBased()))
+                .withNotes().build();
+
+        DeleteMeetingNoteCommand deleteMeetingNoteCommand = new DeleteMeetingNoteCommand(INDEX_FIRST, VALID_MEETING_NOTEID);
+
+        String expectedMessage = String.format(DeleteMeetingNoteCommand.MESSAGE_DELETE_NOTE_SUCCESS, editedMeeting);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setMeeting(firstMeeting, editedMeeting);
+
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false);
+
+        assertCommandSuccess(deleteMeetingNoteCommand, model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidMeetingIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredMeetingList().size() + 1);
+        DeleteMeetingNoteCommand deleteMeetingNoteCommand = new DeleteMeetingNoteCommand(outOfBoundIndex, VALID_MEETING_NOTEID);
+
+        assertCommandFailure(deleteMeetingNoteCommand, model, Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of address book
+     */
+    @Test
+    public void execute_invalidMeetingIndexFilteredList_failure() {
+        showMeetingAtIndex(model, INDEX_FIRST);
+        Index outOfBoundIndex = INDEX_SECOND;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getMeetingList().size());
+
+        DeleteMeetingNoteCommand deleteMeetingNoteCommand = new DeleteMeetingNoteCommand(outOfBoundIndex, VALID_MEETING_NOTEID);
+
+        assertCommandFailure(deleteMeetingNoteCommand, model, Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final DeleteMeetingNoteCommand standardCommand = new DeleteMeetingNoteCommand(INDEX_FIRST,
+                VALID_MEETING_NOTEID);
+
+        // same values -> returns true
+        DeleteMeetingNoteCommand commandWithSameValues = new DeleteMeetingNoteCommand(INDEX_FIRST,
+                VALID_MEETING_NOTEID);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new DeleteMeetingNoteCommand(INDEX_SECOND,
+                VALID_MEETING_NOTEID)));
+
+        // same noteID -> returns true
+        assertTrue(standardCommand.equals(new DeleteMeetingNoteCommand(INDEX_FIRST,
+                VALID_MEETING_NOTEID)));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/DeleteNoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteNoteCommandTest.java
@@ -2,9 +2,14 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_CONTACT_NOTEID;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showContactAtIndex;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
-import static seedu.address.testutil.TypicalIndexes.*;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/DeleteNoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteNoteCommandTest.java
@@ -1,0 +1,118 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.*;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.contact.Contact;
+import seedu.address.testutil.ContactBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for DeleteMeetingNoteCommand.
+ */
+public class DeleteNoteCommandTest {
+
+    private static final String NOTE_STUB = "Some note";
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_deleteNoteUnfilteredList_success() {
+        Contact firstContact = model.getFilteredContactList().get(INDEX_THIRD.getZeroBased());
+        Contact editedContact = new ContactBuilder(firstContact).withNotes().build();
+
+        DeleteNoteCommand deleteNoteCommand = new DeleteNoteCommand(INDEX_THIRD, VALID_CONTACT_NOTEID);
+
+        String expectedMessage = String.format(DeleteNoteCommand.MESSAGE_DELETE_NOTE_SUCCESS, editedContact);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setContact(firstContact, editedContact);
+
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false);
+
+        assertCommandSuccess(deleteNoteCommand, model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showContactAtIndex(model, INDEX_FIRST);
+
+        Contact firstContact = model.getFilteredContactList().get(INDEX_FIRST.getZeroBased());
+        Contact editedContact = new ContactBuilder(model.getFilteredContactList()
+                .get(INDEX_FIRST.getZeroBased()))
+                .withNotes().build();
+
+        DeleteNoteCommand deleteNoteCommand = new DeleteNoteCommand(INDEX_FIRST, VALID_CONTACT_NOTEID);
+
+        String expectedMessage = String.format(DeleteNoteCommand.MESSAGE_DELETE_NOTE_SUCCESS, editedContact);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setContact(firstContact, editedContact);
+
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false);
+
+        assertCommandSuccess(deleteNoteCommand, model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidContactIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredContactList().size() + 1);
+        DeleteNoteCommand deleteNoteCommand = new DeleteNoteCommand(outOfBoundIndex, VALID_CONTACT_NOTEID);
+
+        assertCommandFailure(deleteNoteCommand, model, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of address book
+     */
+    @Test
+    public void execute_invalidContactIndexFilteredList_failure() {
+        showContactAtIndex(model, INDEX_FIRST);
+        Index outOfBoundIndex = INDEX_SECOND;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getContactList().size());
+
+        DeleteNoteCommand deleteNoteCommand = new DeleteNoteCommand(outOfBoundIndex, VALID_CONTACT_NOTEID);
+
+        assertCommandFailure(deleteNoteCommand, model, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final DeleteNoteCommand standardCommand = new DeleteNoteCommand(INDEX_FIRST,
+                VALID_CONTACT_NOTEID);
+
+        // same values -> returns true
+        DeleteNoteCommand commandWithSameValues = new DeleteNoteCommand(INDEX_FIRST,
+                VALID_CONTACT_NOTEID);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new DeleteNoteCommand(INDEX_SECOND,
+                VALID_CONTACT_NOTEID)));
+
+        // same noteID -> returns true
+        assertTrue(standardCommand.equals(new DeleteNoteCommand(INDEX_FIRST,
+                VALID_CONTACT_NOTEID)));
+    }
+}


### PR DESCRIPTION
### Description
Notes in contacts or meetings cannot be deleted.

Let's,
* Update Note class to include a `noteID` field. The `noteID` field is an app-wide counter, similar to GitHub's issue system.
* Implement commands to delete notes from contact and meetings based on a given `noteID`

### Related Issue(s)
#115 

### Checklist

- [x] Unit tests have been added or updated.
- [x] Code has been tested locally and works as expected.
- [x] Documentation has been updated, if necessary.
- [x] Dependencies have been checked and updated, if necessary.
- [x] All code follows the project's coding standards and style guidelines.

### Screenshots (if applicable)
[Include any relevant screenshots to help reviewers understand the changes.]