### PR TITLE
Fix InvocationTargetException bug when index is 0

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddMeetingNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMeetingNoteCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 
@@ -29,7 +30,12 @@ public class AddMeetingNoteCommandParser implements Parser<AddMeetingNoteCommand
 
         Index index;
         try {
+            if (Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()) == 0) {
+                throw new IndexOutOfBoundsException();
+            }
             index = Index.fromOneBased(Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
+        } catch (IndexOutOfBoundsException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_MEETING_DISPLAYED_INDEX));
         } catch (Exception e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AddMeetingNoteCommand.MESSAGE_USAGE), e);

--- a/src/main/java/seedu/address/logic/parser/AddNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddNoteCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 
@@ -29,7 +30,12 @@ public class AddNoteCommandParser implements Parser<AddNoteCommand> {
 
         Index index;
         try {
+            if (Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()) == 0) {
+                throw new IndexOutOfBoundsException();
+            }
             index = Index.fromOneBased(Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
+        } catch (IndexOutOfBoundsException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX));
         } catch (NoSuchElementException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE), ive);
         }

--- a/src/main/java/seedu/address/logic/parser/DeleteContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteContactCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 
 import java.util.NoSuchElementException;
@@ -25,10 +26,15 @@ public class DeleteContactCommandParser implements Parser<DeleteContactCommand> 
                 ArgumentTokenizer.tokenize(args, PREFIX_INDEX);
         Index index;
         try {
+            if (Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()) == 0) {
+                throw new IndexOutOfBoundsException();
+            }
             index = Index.fromOneBased(Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
         } catch (NoSuchElementException e) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteContactCommand.MESSAGE_USAGE), e);
+        } catch (IndexOutOfBoundsException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX));
         }
         return new DeleteContactCommand(index);
     }

--- a/src/main/java/seedu/address/logic/parser/DeleteMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteMeetingCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 
 import seedu.address.commons.core.index.Index;
@@ -23,7 +24,12 @@ public class DeleteMeetingCommandParser implements Parser<DeleteMeetingCommand> 
             ArgumentTokenizer.tokenize(args, PREFIX_INDEX);
         Index index;
         try {
+            if (Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()) == 0) {
+                throw new IndexOutOfBoundsException();
+            }
             index = Index.fromOneBased(Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
+        } catch (IndexOutOfBoundsException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_MEETING_DISPLAYED_INDEX));
         } catch (Exception e) {
             throw new ParseException(
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMeetingCommand.MESSAGE_USAGE), e);

--- a/src/main/java/seedu/address/logic/parser/DeleteMeetingNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteMeetingNoteCommandParser.java
@@ -38,8 +38,7 @@ public class DeleteMeetingNoteCommandParser implements Parser<DeleteMeetingNoteC
         }
 
         if (noteID <= 0) {
-            throw new ParseException(String.format(MESSAGE_INVALID_NOTEID,
-                    DeleteMeetingNoteCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_NOTEID));
         }
 
         return new DeleteMeetingNoteCommand(index, noteID);

--- a/src/main/java/seedu/address/logic/parser/DeleteNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteNoteCommandParser.java
@@ -38,8 +38,7 @@ public class DeleteNoteCommandParser implements Parser<DeleteNoteCommand> {
         }
 
         if (noteID <= 0) {
-            throw new ParseException(String.format(MESSAGE_INVALID_NOTEID,
-                    DeleteNoteCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_NOTEID));
         }
 
         return new DeleteNoteCommand(index, noteID);

--- a/src/main/java/seedu/address/logic/parser/EditContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditContactCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
@@ -40,10 +41,15 @@ public class EditContactCommandParser implements Parser<EditContactCommand> {
 
         Index index;
         try {
+            if (Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()) == 0) {
+                throw new IndexOutOfBoundsException();
+            }
             index = Index.fromOneBased(Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
         } catch (NoSuchElementException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditContactCommand.MESSAGE_USAGE), pe);
+        } catch (IndexOutOfBoundsException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);

--- a/src/main/java/seedu/address/logic/parser/EditMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditMeetingCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PLACE;
@@ -34,10 +35,15 @@ public class EditMeetingCommandParser implements Parser<EditMeetingCommand> {
 
         Index index;
         try {
+            if (Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()) == 0) {
+                throw new IndexOutOfBoundsException();
+            }
             index = Index.fromOneBased(Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
         } catch (NoSuchElementException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditMeetingCommand.MESSAGE_USAGE), pe);
+        } catch (IndexOutOfBoundsException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_MEETING_DISPLAYED_INDEX));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TITLE, PREFIX_TIME, PREFIX_PLACE, PREFIX_DESCRIPTION);

--- a/src/main/java/seedu/address/logic/parser/ViewContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewContactCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 
 import seedu.address.commons.core.index.Index;
@@ -23,7 +24,12 @@ public class ViewContactCommandParser implements Parser<ViewContactCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_INDEX);
         Index index;
         try {
+            if (Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()) == 0) {
+                throw new IndexOutOfBoundsException();
+            }
             index = Index.fromOneBased(Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
+        } catch (IndexOutOfBoundsException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX));
         } catch (Exception e) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewContactCommand.MESSAGE_USAGE), e);

--- a/src/main/java/seedu/address/logic/parser/ViewMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewMeetingCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 
 import java.util.NoSuchElementException;
@@ -25,10 +26,15 @@ public class ViewMeetingCommandParser implements Parser<ViewMeetingCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_INDEX);
         Index index;
         try {
+            if (Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()) == 0) {
+                throw new IndexOutOfBoundsException();
+            }
             index = Index.fromOneBased(Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
         } catch (NoSuchElementException e) {
             throw new ParseException(
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewMeetingCommand.MESSAGE_USAGE), e);
+        } catch (IndexOutOfBoundsException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_MEETING_DISPLAYED_INDEX));
         }
         return new ViewMeetingCommand(index);
     }


### PR DESCRIPTION
### Description
This PR fixes a bug related to passing in "0" as an argument for commands that need indexing.

### Checklist
[Make sure to check the boxes that apply. If an item is not applicable, you can remove it.]

- [x] Unit tests have been added or updated.
- [x] Code has been tested locally and works as expected.
- [x] Documentation has been updated, if necessary.
- [x] Dependencies have been checked and updated, if necessary.
- [x] All code follows the project's coding standards and style guidelines.