### PR TITLE
Fix parsing bugs

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddContactToMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddContactToMeetingCommandParser.java
@@ -2,8 +2,8 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
+import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
 
 import seedu.address.logic.commands.AddContactToMeetingCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -21,6 +21,8 @@ public class AddContactToMeetingCommandParser implements Parser<AddContactToMeet
     public AddContactToMeetingCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TITLE);
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_TITLE);
 
         String contactName = argMultimap.getValue(PREFIX_NAME).orElse("");
         String meetingTitle = argMultimap.getValue(PREFIX_TITLE).orElse("");

--- a/src/main/java/seedu/address/logic/parser/AddContactToMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddContactToMeetingCommandParser.java
@@ -2,8 +2,8 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 
 import seedu.address.logic.commands.AddContactToMeetingCommand;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/parser/DeleteContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteContactCommandParser.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
 
 import java.util.NoSuchElementException;
 

--- a/src/main/java/seedu/address/logic/parser/DeleteContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteContactCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
 
 import java.util.NoSuchElementException;
 
@@ -25,6 +26,9 @@ public class DeleteContactCommandParser implements Parser<DeleteContactCommand> 
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_INDEX);
         Index index;
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_INDEX);
+
         try {
             if (Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()) == 0) {
                 throw new IndexOutOfBoundsException();

--- a/src/main/java/seedu/address/logic/parser/DeleteContactFromMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteContactFromMeetingCommandParser.java
@@ -2,8 +2,8 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 
 import seedu.address.logic.commands.DeleteContactFromMeetingCommand;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/parser/DeleteContactFromMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteContactFromMeetingCommandParser.java
@@ -2,8 +2,8 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
+import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
 
 import seedu.address.logic.commands.DeleteContactFromMeetingCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -22,6 +22,8 @@ public class DeleteContactFromMeetingCommandParser implements Parser<DeleteConta
     public DeleteContactFromMeetingCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TITLE);
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_TITLE);
 
         String contactName = argMultimap.getValue(PREFIX_NAME).orElse("");
         String meetingTitle = argMultimap.getValue(PREFIX_TITLE).orElse("");

--- a/src/main/java/seedu/address/logic/parser/DeleteMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteMeetingCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteMeetingCommand;
@@ -22,6 +23,9 @@ public class DeleteMeetingCommandParser implements Parser<DeleteMeetingCommand> 
     public DeleteMeetingCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
             ArgumentTokenizer.tokenize(args, PREFIX_INDEX);
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_INDEX);
+
         Index index;
         try {
             if (Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()) == 0) {

--- a/src/main/java/seedu/address/logic/parser/DeleteMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteMeetingCommandParser.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteMeetingCommand;

--- a/src/main/java/seedu/address/logic/parser/EditContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditContactCommandParser.java
@@ -3,12 +3,7 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/src/main/java/seedu/address/logic/parser/EditContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditContactCommandParser.java
@@ -3,7 +3,12 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/src/main/java/seedu/address/logic/parser/ListContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListContactCommandParser.java
@@ -1,11 +1,7 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 
 import java.util.Arrays;
 import java.util.List;
@@ -29,6 +25,10 @@ public class ListContactCommandParser implements Parser<ListContactCommand> {
         ArgumentMultimap argMultimap =
             ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_ADDRESS, PREFIX_TAG, PREFIX_NOTE);
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                PREFIX_ADDRESS, PREFIX_TAG, PREFIX_NOTE);
+
         String name = argMultimap.getValue(PREFIX_NAME).orElse("").trim();
         List<String> nameKeywords = Arrays.asList(name.split("\\s+"));
         String phone = argMultimap.getValue(PREFIX_PHONE).orElse("");

--- a/src/main/java/seedu/address/logic/parser/ListContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListContactCommandParser.java
@@ -1,7 +1,11 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.parser.CliSyntax.*;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/seedu/address/logic/parser/ListMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListMeetingCommandParser.java
@@ -1,6 +1,11 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PLACE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME_END;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME_START;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/seedu/address/logic/parser/ListMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListMeetingCommandParser.java
@@ -1,11 +1,6 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PLACE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME_END;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME_START;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -28,6 +23,10 @@ public class ListMeetingCommandParser implements Parser<ListMeetingCommand> {
         ArgumentMultimap argMultimap =
             ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_TIME_START, PREFIX_TIME_END, PREFIX_PLACE,
                 PREFIX_DESCRIPTION, PREFIX_NOTE);
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TITLE, PREFIX_TIME_START, PREFIX_TIME_END, PREFIX_PLACE,
+                PREFIX_DESCRIPTION, PREFIX_NOTE);
+
         String title = argMultimap.getValue(PREFIX_TITLE).orElse("").trim();
         List<String> titleKeywords = Arrays.asList(title.split("\\s+"));
         String timeStart = argMultimap.getValue(PREFIX_TIME_START).orElse("");

--- a/src/main/java/seedu/address/logic/parser/ViewContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewContactCommandParser.java
@@ -2,7 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ViewContactCommand;
@@ -22,6 +22,9 @@ public class ViewContactCommandParser implements Parser<ViewContactCommand> {
      */
     public ViewContactCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_INDEX);
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_INDEX);
+
         Index index;
         try {
             if (Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()) == 0) {

--- a/src/main/java/seedu/address/logic/parser/ViewContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewContactCommandParser.java
@@ -2,7 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ViewContactCommand;

--- a/src/main/java/seedu/address/logic/parser/ViewMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewMeetingCommandParser.java
@@ -24,6 +24,9 @@ public class ViewMeetingCommandParser implements Parser<ViewMeetingCommand> {
      */
     public ViewMeetingCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_INDEX);
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_INDEX);
+
         Index index;
         try {
             if (Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()) == 0) {


### PR DESCRIPTION
### Description
This PR fixes more bugs:
* Incorrect handling of when id is 0 for deletenote commands.
* Incorrect behaviour when duplicate prefixes are present.

### Checklist
[Make sure to check the boxes that apply. If an item is not applicable, you can remove it.]

- [x] Unit tests have been added or updated.
- [x] Code has been tested locally and works as expected.
- [x] Documentation has been updated, if necessary.
- [x] Dependencies have been checked and updated, if necessary.
- [x] All code follows the project's coding standards and style guidelines.