### PR TITLE
Implement sort for contacts and meetings

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddContactToMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactToMeetingCommand.java
@@ -13,6 +13,7 @@ import seedu.address.model.contact.Contact;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.ui.AppState;
 
+
 /**
  * Adds a contact to a meeting.
  */
@@ -31,6 +32,7 @@ public class AddContactToMeetingCommand extends Command {
     public static final String MESSAGE_ADD_CONTACT_SUCCESS = "Added contact '%s' to Meeting '%s'";
     public static final String MESSAGE_CONTACT_NOT_FOUND = "The person specified is not created";
     public static final String MESSAGE_MEETING_NOT_FOUND = "The meeting specified is not created";
+    public static final String MESSAGE_DUPLICATE_CONTACT = "This contact already exists in the meeting";
 
     private final String meetingTitle;
     private final String contactName;
@@ -75,6 +77,9 @@ public class AddContactToMeetingCommand extends Command {
             throw new CommandException(MESSAGE_MEETING_NOT_FOUND);
         }
         ArrayList<Contact> listOfContacts = new ArrayList<>(meetingToEdit.getContacts());
+        if (listOfContacts.stream().anyMatch(contact::isSameContact)) {
+            throw new CommandException(MESSAGE_DUPLICATE_CONTACT);
+        }
         listOfContacts.add(contact);
 
         Meeting editedMeeting = new Meeting(

--- a/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
@@ -34,6 +34,8 @@ public class AddMeetingCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New meeting added: %1$s";
 
+    public static final String MESSAGE_DUPLICATE_MEETING = "This meeting already exists in the address book";
+
     private final Meeting toAdd;
 
     /**
@@ -47,7 +49,9 @@ public class AddMeetingCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-
+        if (model.hasMeeting(toAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_MEETING);
+        }
         model.addMeeting(toAdd);
 
         AppState appState = AppState.getInstance();

--- a/src/main/java/seedu/address/logic/commands/ListContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListContactCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.contact.ContactFilterPredicate;
 
@@ -25,6 +26,7 @@ public class ListContactCommand extends Command {
         requireNonNull(model);
         model.updateFilteredContactList(predicate);
 
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(String.format(Messages.MESSAGE_CONTACTS_LISTED_OVERVIEW,
+                model.getFilteredContactList().size()));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddContactToMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddContactToMeetingCommandParser.java
@@ -21,7 +21,7 @@ public class AddContactToMeetingCommandParser implements Parser<AddContactToMeet
     public AddContactToMeetingCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TITLE);
-
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_TITLE);
         String contactName = argMultimap.getValue(PREFIX_NAME).orElse("");
         String meetingTitle = argMultimap.getValue(PREFIX_TITLE).orElse("");
         boolean raiseException = contactName.length() < 1 || meetingTitle.length() < 1;

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -90,6 +90,11 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void addContact(Contact c) {
         contacts.add(c);
+        contacts.sort();
+    }
+
+    public void sortContacts() {
+        contacts.sort();
     }
 
     /**
@@ -117,7 +122,8 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public boolean hasMeeting(Meeting meeting) {
         requireNonNull(meeting);
-        return meetings.contains(meeting);
+
+        return meetings.checkDuplicate(meeting);
     }
 
     /**
@@ -125,6 +131,11 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void addMeeting(Meeting meeting) {
         meetings.add(meeting);
+        meetings.sort();
+    }
+
+    public void sortMeetings() {
+        meetings.sort();
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -12,7 +12,9 @@ import seedu.address.model.meeting.Meeting;
  * The API of the Model component.
  */
 public interface Model {
-    /** {@code Predicate} that always evaluate to true */
+    /**
+     * {@code Predicate} that always evaluate to true
+     */
     Predicate<Contact> PREDICATE_SHOW_ALL_CONTACTS = unused -> true;
     Predicate<Meeting> PREDICATE_SHOW_ALL_MEETINGS = unused -> true;
 
@@ -53,7 +55,9 @@ public interface Model {
      */
     void setAddressBook(ReadOnlyAddressBook addressBook);
 
-    /** Returns the AddressBook */
+    /**
+     * Returns the AddressBook
+     */
     ReadOnlyAddressBook getAddressBook();
 
     /**
@@ -81,11 +85,14 @@ public interface Model {
      */
     void setContact(Contact target, Contact editedContact);
 
-    /** Returns an unmodifiable view of the filtered contact list */
+    /**
+     * Returns an unmodifiable view of the filtered contact list
+     */
     ObservableList<Contact> getFilteredContactList();
 
     /**
      * Updates the filter of the filtered contact list to filter by the given {@code predicate}.
+     *
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredContactList(Predicate<Contact> predicate);
@@ -114,11 +121,20 @@ public interface Model {
      */
     boolean hasMeeting(Meeting meeting);
 
-    /** Returns an unmodifiable view of the filtered contact list */
+    /**
+     * Returns an unmodifiable view of the filtered contact list
+     */
     ObservableList<Meeting> getFilteredMeetingList();
+
+    /* Sorts the uniqueContactList in lexicographical order */
+    void sortContacts();
+
+    /* Sorts the uniqueContactList in chronological order */
+    void sortMeetings();
 
     /**
      * Updates the filter of the filtered meeting list to filter by the given {@code predicate}.
+     *
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredMeetingList(Predicate<Meeting> predicate);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -156,12 +156,24 @@ public class ModelManager implements Model {
     public void updateFilteredContactList(Predicate<Contact> predicate) {
         requireNonNull(predicate);
         filteredContacts.setPredicate(predicate);
+        addressBook.sortContacts();
+    }
+
+    @Override
+    public void sortContacts() {
+        addressBook.sortContacts();
     }
 
     @Override
     public void updateFilteredMeetingList(Predicate<Meeting> predicate) {
         requireNonNull(predicate);
         filteredMeetings.setPredicate(predicate);
+        addressBook.sortMeetings();
+    }
+
+    @Override
+    public void sortMeetings() {
+        addressBook.sortMeetings();
     }
 
     @Override
@@ -177,8 +189,8 @@ public class ModelManager implements Model {
 
         ModelManager otherModelManager = (ModelManager) other;
         return addressBook.equals(otherModelManager.addressBook)
-            && userPrefs.equals(otherModelManager.userPrefs)
-            && filteredContacts.equals(otherModelManager.filteredContacts)
-            && filteredMeetings.equals(otherModelManager.filteredMeetings);
+                && userPrefs.equals(otherModelManager.userPrefs)
+                && filteredContacts.equals(otherModelManager.filteredContacts)
+                && filteredMeetings.equals(otherModelManager.filteredMeetings);
     }
 }

--- a/src/main/java/seedu/address/model/contact/Contact.java
+++ b/src/main/java/seedu/address/model/contact/Contact.java
@@ -16,7 +16,7 @@ import seedu.address.model.tag.Tag;
  * Represents a Contact in the address book.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class Contact {
+public class Contact implements Comparable<Contact> {
 
     // Identity fields
     private final Name name;
@@ -111,7 +111,7 @@ public class Contact {
         }
 
         return otherContact != null
-            && otherContact.getName().equals(getName());
+                && otherContact.getName().equals(getName());
     }
 
     /**
@@ -131,11 +131,17 @@ public class Contact {
 
         Contact otherContact = (Contact) other;
         return name.equals(otherContact.name)
-            && phone.equals(otherContact.phone)
-            && email.equals(otherContact.email)
-            && address.equals(otherContact.address)
-            && tags.equals(otherContact.tags)
-            && notes.equals(otherContact.notes);
+                && phone.equals(otherContact.phone)
+                && email.equals(otherContact.email)
+                && address.equals(otherContact.address)
+                && tags.equals(otherContact.tags)
+                && notes.equals(otherContact.notes);
+    }
+
+    @Override
+    public int compareTo(Contact other) {
+        Name otherName = other.name;
+        return this.name.toString().compareTo(otherName.toString());
     }
 
     @Override
@@ -147,13 +153,13 @@ public class Contact {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-            .add("name", name)
-            .add("phone", phone)
-            .add("email", email)
-            .add("address", address)
-            .add("tags", tags)
-            .add("notes", notes)
-            .toString();
+                .add("name", name)
+                .add("phone", phone)
+                .add("email", email)
+                .add("address", address)
+                .add("tags", tags)
+                .add("notes", notes)
+                .toString();
     }
 
 }

--- a/src/main/java/seedu/address/model/contact/UniqueContactList.java
+++ b/src/main/java/seedu/address/model/contact/UniqueContactList.java
@@ -3,6 +3,7 @@ package seedu.address.model.contact;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -17,7 +18,7 @@ import seedu.address.model.contact.exceptions.DuplicateContactException;
  * and updating of contacts uses Contact#isSameContact(Contact) for equality so as to ensure that
  * the contact being added or updated is unique in terms of identity in the UniqueContactList. However, the removal of
  * a contact uses Contact#equals(Object) so as to ensure that the contact with exactly the same fields will be removed.
- *
+ * <p>
  * Supports a minimal set of list operations.
  *
  * @see Contact#isSameContact(Contact)
@@ -95,6 +96,10 @@ public class UniqueContactList implements Iterable<Contact> {
         }
 
         internalList.setAll(contacts);
+    }
+
+    public void sort() {
+        Collections.sort(internalList);
     }
 
     /**

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -16,7 +16,7 @@ import seedu.address.model.note.Note;
  * Represents a Meeting in Notenote.
  * Guarantees: details are present and not null, field values are validated.
  */
-public class Meeting {
+public class Meeting implements Comparable<Meeting> {
 
     private Title title;
 
@@ -91,13 +91,26 @@ public class Meeting {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-            .add("title", title)
-            .add("time", time)
-            .add("place", place)
-            .add("description", description)
-            .add("notes", notes)
-            .add("contacts", contacts)
-            .toString();
+                .add("title", title)
+                .add("time", time)
+                .add("place", place)
+                .add("description", description)
+                .add("notes", notes)
+                .add("contacts", contacts)
+                .toString();
+    }
+
+    /**
+     * Returns true if both contacts have the same name.
+     * This defines a weaker notion of equality between two contacts.
+     */
+    public boolean isSameMeeting(Meeting otherMeeting) {
+        if (otherMeeting == this) {
+            return true;
+        }
+
+        return otherMeeting != null
+                && otherMeeting.getTitle().equals(getTitle());
     }
 
     @Override
@@ -113,11 +126,22 @@ public class Meeting {
 
         Meeting otherMeeting = (Meeting) other;
         return title.equals(otherMeeting.title)
-            && time.equals(otherMeeting.time)
-            && place.equals(otherMeeting.place)
-            && description.equals(otherMeeting.description)
-            && notes.equals(otherMeeting.notes)
-            && contacts.equals(otherMeeting.contacts);
+                && time.equals(otherMeeting.time)
+                && place.equals(otherMeeting.place)
+                && description.equals(otherMeeting.description)
+                && notes.equals(otherMeeting.notes)
+                && contacts.equals(otherMeeting.contacts);
+    }
+
+    @Override
+    public int compareTo(Meeting other) {
+        Time otherTime = other.time;
+        if (time.getValue().isBefore(otherTime.getValue())) {
+            return -1;
+        } else if (time.getValue().isAfter(otherTime.getValue())) {
+            return 1;
+        }
+        return 0;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/meeting/MeetingList.java
+++ b/src/main/java/seedu/address/model/meeting/MeetingList.java
@@ -3,6 +3,7 @@ package seedu.address.model.meeting;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -52,6 +53,14 @@ public class MeetingList implements Iterable<Meeting> {
         return internalList.stream().anyMatch(toCheck::equals);
     }
 
+    /**
+     * Checks if a given meeting has the same title as another meeting in the list
+     */
+    public boolean checkDuplicate(Meeting toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isSameMeeting);
+    }
+
     @Override
     public Iterator<Meeting> iterator() {
         return internalList.iterator();
@@ -96,6 +105,11 @@ public class MeetingList implements Iterable<Meeting> {
 
         internalList.setAll(meetings);
     }
+
+    public void sort() {
+        Collections.sort(internalList);
+    }
+
 
     @Override
     public String toString() {

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -70,7 +70,8 @@ public class LogicManagerTest {
     @Test
     public void execute_validCommand_success() throws Exception {
         String listCommand = ListContactCommand.COMMAND_WORD;
-        assertCommandSuccess(listCommand, ListContactCommand.MESSAGE_SUCCESS, model);
+        assertCommandSuccess(listCommand, String.format(Messages.MESSAGE_CONTACTS_LISTED_OVERVIEW,
+                0), model);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AddContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddContactCommandTest.java
@@ -189,6 +189,16 @@ public class AddContactCommandTest {
         public void updateFilteredMeetingList(Predicate<Meeting> predicate) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void sortContacts() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void sortMeetings() {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddMeetingCommandTest.java
@@ -24,6 +24,7 @@ import seedu.address.testutil.MeetingBuilder;
 
 public class AddMeetingCommandTest {
 
+
     @Test
     public void constructor_nullMeeting_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new AddMeetingCommand(null));
@@ -140,7 +141,7 @@ public class AddMeetingCommandTest {
 
         @Override
         public boolean hasMeeting(Meeting meeting) {
-            throw new AssertionError("This method should not be called.");
+            return false;
         }
 
         @Override
@@ -175,6 +176,16 @@ public class AddMeetingCommandTest {
 
         @Override
         public void updateFilteredMeetingList(Predicate<Meeting> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void sortContacts() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void sortMeetings() {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/EditContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditContactCommandTest.java
@@ -70,7 +70,7 @@ public class EditContactCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setContact(lastContact, editedContact);
-
+        expectedModel.sortContacts();
         CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false);
 
         assertCommandSuccess(editContactCommand, model, expectedCommandResult, expectedModel);
@@ -106,7 +106,7 @@ public class EditContactCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setContact(model.getFilteredContactList().get(0), editedContact);
-
+        expectedModel.sortContacts();
         CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false);
 
         assertCommandSuccess(editContactCommand, model, expectedCommandResult, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/EditMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditMeetingCommandTest.java
@@ -45,6 +45,7 @@ public class EditMeetingCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setMeeting(model.getFilteredMeetingList().get(0), editedMeeting);
+        expectedModel.sortMeetings();
 
         CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false);
 
@@ -69,7 +70,7 @@ public class EditMeetingCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setMeeting(lastMeeting, editedMeeting);
-
+        expectedModel.sortMeetings();
         CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false);
 
         assertCommandSuccess(editMeetingCommand, model, expectedCommandResult, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/ListContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListContactCommandTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.Messages.MESSAGE_CONTACTS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showContactAtIndex;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalContactsAddressBook;
@@ -30,14 +31,14 @@ public class ListContactCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() throws ParseException {
-        CommandResult expectedCommandResult = new CommandResult(ListContactCommand.MESSAGE_SUCCESS);
+        CommandResult expectedCommandResult = new CommandResult(String.format(MESSAGE_CONTACTS_LISTED_OVERVIEW, 7));
         ListContactCommand actualCommand = new ListContactCommandParser().parse("list");
         assertCommandSuccess(actualCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() throws ParseException {
-        CommandResult expectedCommandResult = new CommandResult(ListContactCommand.MESSAGE_SUCCESS);
+        CommandResult expectedCommandResult = new CommandResult(String.format(MESSAGE_CONTACTS_LISTED_OVERVIEW, 7));
         ListContactCommand actualCommand = new ListContactCommandParser().parse("list");
         showContactAtIndex(model, INDEX_FIRST);
         assertCommandSuccess(actualCommand, model, expectedCommandResult, expectedModel);


### PR DESCRIPTION
The order of the UniqueContactList and MeetingList is FCFS

This way of presenting the entries is not user friendly

Let's,
Implement lexicographical order sort for the UniqueContactList and chrnological order sort for the MeetingList

### Related Issue(s)
Fixes #117 

### Checklist
[Make sure to check the boxes that apply. If an item is not applicable, you can remove it.]

- [X] Unit tests have been added or updated.
- [X] Code has been tested locally and works as expected.
- [X] Dependencies have been checked and updated, if necessary.
- [X] All code follows the project's coding standards and style guidelines.

### Screenshots (if applicable)
[Include any relevant screenshots to help reviewers understand the changes.]

