### PR TITLE
Bug fixes with Notes feature

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -384,7 +384,7 @@ giving users the ability to edit previous notes, but that is outside the scope o
 ### Implementation (Add Notes)
 
 A new `Note` class is created, which stores the contents of the note as a string. The `Contact`/`Meeting` model is then updated
-to include a new `notes` attribute of type `LinkedHashSet<Note>`.
+to include a new `notes` attribute of type `ArrayList<Note>`.
 
 To distinguish between adding notes to contacts and meetings, 2 separate Command classes are created, namely 
 `AddNoteCommand` (for contacts) and `AddMeetingNoteCommand` (for meetings). These classes will then call 
@@ -401,21 +401,14 @@ updated as well.
 
 ### Implementation (Delete Notes)
 
-Within each `Note` class, there is a `noteID` field which is stored as an `int`. `noteID` is assigned based on the total number
-of notes in the system i.e. if there are 5 notes in the app now, the next note will have a `noteID` of 6. In this manner, each
-Note thus has a unique `noteID`.
-
 Once again, there are separate commands for deleting notes from contacts and from meetings. The relationship between the Command
 and respective Parser classes is similar to the one described for adding Notes.
 
-In terms of execution, a user will pass the `noteID` of the Note to be deleted as an argument. NoteNote will then iterate through
-the HashSet, and when a Note's `noteID` matches the one specified by the user, will remove the Note from the LinkedHashSet accordingly.
+In terms of execution, a user will pass the `noteID` of the Note to be deleted as an argument. The `noteID` is the index of the
+note, which starts from 1 for each `Contact`/`Meeting`. 
 
-The `Contact`/`Meeting` model will then be updated with the new LinkedHashSet of Notes.
-
-Additionally, it is pertinent to note that the exact value of `noteID` is unimportant. In this implementation,
-it is used as a way to index Notes in the LinkedHashSet. As such, on opening and shutting down the app, the noteID may change --
-this is to be expected. However, the relative order of notes within each Contact/Meeting should be unchanged.
+The `Contact`/`Meeting` model will then be updated with the new ArrayList of Notes. AppState is updated as well to ensure
+the GUI is refreshed.
 
 ### Design Considerations
 

--- a/src/main/java/seedu/address/logic/commands/AddMeetingNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMeetingNoteCommand.java
@@ -5,9 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;

--- a/src/main/java/seedu/address/logic/commands/AddMeetingNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMeetingNoteCommand.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -58,7 +59,7 @@ public class AddMeetingNoteCommand extends Command {
 
         Meeting meetingToEdit = lastShownList.get(index.getZeroBased());
 
-        Set<Note> mutableNotesList = new LinkedHashSet<>(meetingToEdit.getNotes());
+        ArrayList<Note> mutableNotesList = new ArrayList<>(meetingToEdit.getNotes());
 
         if (mutableNotesList.contains(note)) {
             throw new CommandException(Messages.MESSAGE_DUPLICATE_NOTES);

--- a/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
@@ -5,9 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;

--- a/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -58,7 +59,7 @@ public class AddNoteCommand extends Command {
 
         Contact contactToEdit = lastShownList.get(index.getZeroBased());
 
-        Set<Note> mutableNotesList = new LinkedHashSet<>(contactToEdit.getNotes());
+        ArrayList<Note> mutableNotesList = new ArrayList<>(contactToEdit.getNotes());
 
         if (mutableNotesList.contains(note)) {
             throw new CommandException(Messages.MESSAGE_DUPLICATE_NOTES);

--- a/src/main/java/seedu/address/logic/commands/DeleteMeetingNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteMeetingNoteCommand.java
@@ -1,10 +1,12 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_NOTEID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -13,6 +15,7 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.note.Note;
@@ -61,25 +64,32 @@ public class DeleteMeetingNoteCommand extends Command {
 
         Meeting meetingToEdit = lastShownList.get(index.getZeroBased());
 
-        Set<Note> mutableNotesList = new LinkedHashSet<>(meetingToEdit.getNotes());
-        Iterator<Note> iterator = mutableNotesList.iterator();
-        while (iterator.hasNext()) {
-            Note note = iterator.next();
-            if (note.getNoteID() == noteID) {
-                iterator.remove();
-                isSuccessful = true;
-            }
+        ArrayList<Note> mutableNotesList = new ArrayList<>(meetingToEdit.getNotes());
+
+        if (noteID > mutableNotesList.size()) {
+            throw new CommandException(String.format(MESSAGE_INVALID_NOTEID));
         }
 
-        LinkedHashSet<Note> newNoteSet = new LinkedHashSet<>();
-        iterator = mutableNotesList.iterator();
-        while (iterator.hasNext()) {
-            newNoteSet.add(iterator.next());
-        }
+        mutableNotesList.remove(noteID - 1);
+        isSuccessful = true;
+//        Iterator<Note> iterator = mutableNotesList.iterator();
+//        while (iterator.hasNext()) {
+//            Note note = iterator.next();
+//            if (note.getNoteID() == noteID) {
+//                iterator.remove();
+//                isSuccessful = true;
+//            }
+//        }
+//
+//        LinkedHashSet<Note> newNoteSet = new LinkedHashSet<>();
+//        iterator = mutableNotesList.iterator();
+//        while (iterator.hasNext()) {
+//            newNoteSet.add(iterator.next());
+//        }
 
         Meeting editedMeeting = new Meeting(
                 meetingToEdit.getTitle(), meetingToEdit.getTime(), meetingToEdit.getPlace(),
-                meetingToEdit.getDescription(), newNoteSet, meetingToEdit.getContacts());
+                meetingToEdit.getDescription(), mutableNotesList, meetingToEdit.getContacts());
 
         model.setMeeting(meetingToEdit, editedMeeting);
         model.updateFilteredMeetingList(Model.PREDICATE_SHOW_ALL_MEETINGS);

--- a/src/main/java/seedu/address/logic/commands/DeleteMeetingNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteMeetingNoteCommand.java
@@ -7,15 +7,11 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
 
 import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.note.Note;
@@ -72,20 +68,6 @@ public class DeleteMeetingNoteCommand extends Command {
 
         mutableNotesList.remove(noteID - 1);
         isSuccessful = true;
-//        Iterator<Note> iterator = mutableNotesList.iterator();
-//        while (iterator.hasNext()) {
-//            Note note = iterator.next();
-//            if (note.getNoteID() == noteID) {
-//                iterator.remove();
-//                isSuccessful = true;
-//            }
-//        }
-//
-//        LinkedHashSet<Note> newNoteSet = new LinkedHashSet<>();
-//        iterator = mutableNotesList.iterator();
-//        while (iterator.hasNext()) {
-//            newNoteSet.add(iterator.next());
-//        }
 
         Meeting editedMeeting = new Meeting(
                 meetingToEdit.getTitle(), meetingToEdit.getTime(), meetingToEdit.getPlace(),

--- a/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
@@ -7,10 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
 
 import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
@@ -72,21 +69,6 @@ public class DeleteNoteCommand extends Command {
 
         mutableNotesList.remove(noteID - 1);
         isSuccessful = true;
-//
-//        Iterator<Note> iterator = mutableNotesList.iterator();
-//        while (iterator.hasNext()) {
-//            Note note = iterator.next();
-//            if (note.getNoteID() == noteID) {
-//                iterator.remove();
-//                isSuccessful = true;
-//            }
-//        }
-//
-//        LinkedHashSet<Note> newNoteSet = new LinkedHashSet<>();
-//        iterator = mutableNotesList.iterator();
-//        while (iterator.hasNext()) {
-//            newNoteSet.add(iterator.next());
-//        }
 
         Contact editedContact = new Contact(
                 contactToEdit.getName(), contactToEdit.getPhone(), contactToEdit.getEmail(),

--- a/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
@@ -1,10 +1,12 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_NOTEID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -62,25 +64,33 @@ public class DeleteNoteCommand extends Command {
 
         Contact contactToEdit = lastShownList.get(index.getZeroBased());
 
-        Set<Note> mutableNotesList = new LinkedHashSet<>(contactToEdit.getNotes());
-        Iterator<Note> iterator = mutableNotesList.iterator();
-        while (iterator.hasNext()) {
-            Note note = iterator.next();
-            if (note.getNoteID() == noteID) {
-                iterator.remove();
-                isSuccessful = true;
-            }
+        ArrayList<Note> mutableNotesList = new ArrayList<>(contactToEdit.getNotes());
+
+        if (noteID > mutableNotesList.size()) {
+            throw new CommandException(String.format(MESSAGE_INVALID_NOTEID));
         }
 
-        LinkedHashSet<Note> newNoteSet = new LinkedHashSet<>();
-        iterator = mutableNotesList.iterator();
-        while (iterator.hasNext()) {
-            newNoteSet.add(iterator.next());
-        }
+        mutableNotesList.remove(noteID - 1);
+        isSuccessful = true;
+//
+//        Iterator<Note> iterator = mutableNotesList.iterator();
+//        while (iterator.hasNext()) {
+//            Note note = iterator.next();
+//            if (note.getNoteID() == noteID) {
+//                iterator.remove();
+//                isSuccessful = true;
+//            }
+//        }
+//
+//        LinkedHashSet<Note> newNoteSet = new LinkedHashSet<>();
+//        iterator = mutableNotesList.iterator();
+//        while (iterator.hasNext()) {
+//            newNoteSet.add(iterator.next());
+//        }
 
         Contact editedContact = new Contact(
                 contactToEdit.getName(), contactToEdit.getPhone(), contactToEdit.getEmail(),
-                contactToEdit.getAddress(), contactToEdit.getTags(), newNoteSet);
+                contactToEdit.getAddress(), contactToEdit.getTags(), mutableNotesList);
 
         model.setContact(contactToEdit, editedContact);
         model.updateFilteredContactList(Model.PREDICATE_SHOW_ALL_CONTACTS);

--- a/src/main/java/seedu/address/logic/commands/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditContactCommand.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CONTACTS;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -109,7 +110,7 @@ public class EditContactCommand extends Command {
         Email updatedEmail = editContactDescriptor.getEmail().orElse(contactToEdit.getEmail());
         Address updatedAddress = editContactDescriptor.getAddress().orElse(contactToEdit.getAddress());
         Set<Tag> updatedTags = editContactDescriptor.getTags().orElse(contactToEdit.getTags());
-        Set<Note> updatedNotes = editContactDescriptor.getNotes().orElse(contactToEdit.getNotes());
+        ArrayList<Note> updatedNotes = editContactDescriptor.getNotes().orElse(contactToEdit.getNotes());
 
         return new Contact(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedNotes);
     }
@@ -148,7 +149,7 @@ public class EditContactCommand extends Command {
         private Email email;
         private Address address;
         private Set<Tag> tags;
-        private Set<Note> notes;
+        private ArrayList<Note> notes;
 
         public EditContactDescriptor() {
         }
@@ -226,8 +227,8 @@ public class EditContactCommand extends Command {
          * Sets {@code notes} to this object's {@code notes}.
          * A defensive copy of {@code notes} is used internally.
          */
-        public void setNotes(Set<Note> notes) {
-            this.notes = (notes != null) ? new LinkedHashSet<>(notes) : null;
+        public void setNotes(ArrayList<Note> notes) {
+            this.notes = (notes != null) ? new ArrayList<>(notes) : null;
         }
 
         /**
@@ -235,8 +236,8 @@ public class EditContactCommand extends Command {
          * if modification is attempted.
          * Returns {@code Optional#empty()} if {@code notes} is null.
          */
-        public Optional<Set<Note>> getNotes() {
-            return (notes != null) ? Optional.of(Collections.unmodifiableSet(notes)) : Optional.empty();
+        public Optional<ArrayList<Note>> getNotes() {
+            return (notes != null) ? Optional.of(new ArrayList<>(Collections.unmodifiableList(notes))) : Optional.empty();
         }
 
         @Override

--- a/src/main/java/seedu/address/logic/commands/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditContactCommand.java
@@ -12,7 +12,6 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CONTACTS;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -237,7 +236,8 @@ public class EditContactCommand extends Command {
          * Returns {@code Optional#empty()} if {@code notes} is null.
          */
         public Optional<ArrayList<Note>> getNotes() {
-            return (notes != null) ? Optional.of(new ArrayList<>(Collections.unmodifiableList(notes))) : Optional.empty();
+            return (notes != null) ? Optional.of(new ArrayList<>(Collections.unmodifiableList(notes)))
+                    : Optional.empty();
         }
 
         @Override

--- a/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
@@ -106,7 +106,7 @@ public class EditMeetingCommand extends Command {
         Time updatedTime = editMeetingDescriptor.getTime().orElse(meetingToEdit.getTime());
         Place updatedPlace = editMeetingDescriptor.getPlace().orElse(meetingToEdit.getPlace());
         Description updatedDescription = editMeetingDescriptor.getDescription().orElse(meetingToEdit.getDescription());
-        Set<Note> updatedNotes = editMeetingDescriptor.getNotes().orElse(meetingToEdit.getNotes());
+        ArrayList<Note> updatedNotes = editMeetingDescriptor.getNotes().orElse(meetingToEdit.getNotes());
         ArrayList<Contact> updatedContacts = editMeetingDescriptor.getContacts().orElse(meetingToEdit.getContacts());
         return new Meeting(updatedTitle, updatedTime, updatedPlace, updatedDescription, updatedNotes, updatedContacts);
     }
@@ -145,7 +145,7 @@ public class EditMeetingCommand extends Command {
         private Place place;
         private Description description;
 
-        private Set<Note> notes;
+        private ArrayList<Note> notes;
         private ArrayList<Contact> contacts;
 
         public EditMeetingDescriptor() {
@@ -206,8 +206,8 @@ public class EditMeetingCommand extends Command {
          * Sets {@code notes} to this object's {@code notes}.
          * A defensive copy of {@code notes} is used internally.
          */
-        public void setNotes(Set<Note> notes) {
-            this.notes = (notes != null) ? new LinkedHashSet<>(notes) : null;
+        public void setNotes(ArrayList<Note> notes) {
+            this.notes = notes;
         }
 
         /**
@@ -215,8 +215,8 @@ public class EditMeetingCommand extends Command {
          * if modification is attempted.
          * Returns {@code Optional#empty()} if {@code notes} is null.
          */
-        public Optional<Set<Note>> getNotes() {
-            return (notes != null) ? Optional.of(Collections.unmodifiableSet(notes)) : Optional.empty();
+        public Optional<ArrayList<Note>> getNotes() {
+            return (notes != null) ? Optional.of(new ArrayList<>(Collections.unmodifiableList(notes))) : Optional.empty();
         }
 
         public void setContacts(ArrayList<Contact> contacts) {

--- a/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
@@ -10,11 +10,9 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_MEETINGS;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
@@ -216,7 +214,8 @@ public class EditMeetingCommand extends Command {
          * Returns {@code Optional#empty()} if {@code notes} is null.
          */
         public Optional<ArrayList<Note>> getNotes() {
-            return (notes != null) ? Optional.of(new ArrayList<>(Collections.unmodifiableList(notes))) : Optional.empty();
+            return (notes != null) ? Optional.of(new ArrayList<>(Collections.unmodifiableList(notes)))
+                    : Optional.empty();
         }
 
         public void setContacts(ArrayList<Contact> contacts) {

--- a/src/main/java/seedu/address/logic/parser/AddContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddContactCommandParser.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
 import java.util.Set;
 
 import seedu.address.logic.commands.AddContactCommand;
@@ -46,7 +47,7 @@ public class AddContactCommandParser implements Parser<AddContactCommand> {
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-        Set<Note> noteList = ParserUtil.parseNotes(argMultimap.getAllValues(PREFIX_NOTE));
+        ArrayList<Note> noteList = ParserUtil.parseNotes(argMultimap.getAllValues(PREFIX_NOTE));
         Contact contact = new Contact(name, phone, email, address, tagList, noteList);
 
         return new AddContactCommand(contact);

--- a/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
@@ -45,7 +45,7 @@ public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
         Place place = ParserUtil.parsePlace(argMultimap.getValue(PREFIX_PLACE).get());
         Description description =
             ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
-        Set<Note> noteList = ParserUtil.parseNotes(argMultimap.getAllValues(PREFIX_NOTE));
+        ArrayList<Note> noteList = ParserUtil.parseNotes(argMultimap.getAllValues(PREFIX_NOTE));
         Meeting meeting = new Meeting(title, time, place, description, noteList, new ArrayList<>());
         return new AddMeetingCommand(meeting);
     }

--- a/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 
 import java.util.ArrayList;
-import java.util.Set;
 
 import seedu.address.logic.commands.AddMeetingCommand;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/parser/DeleteMeetingNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteMeetingNoteCommandParser.java
@@ -2,8 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.lang.Integer.parseInt;
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_NOTEID;
+import static seedu.address.logic.Messages.*;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
 
@@ -30,8 +29,13 @@ public class DeleteMeetingNoteCommandParser implements Parser<DeleteMeetingNoteC
         Index index;
         int noteID;
         try {
+            if (Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()) == 0) {
+                throw new IndexOutOfBoundsException();
+            }
             index = Index.fromOneBased(parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
             noteID = parseInt(argMultimap.getValue(PREFIX_NOTE_ID).orElse(""));
+        } catch (IndexOutOfBoundsException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_MEETING_DISPLAYED_INDEX));
         } catch (Exception e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     DeleteMeetingNoteCommand.MESSAGE_USAGE), e);

--- a/src/main/java/seedu/address/logic/parser/DeleteMeetingNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteMeetingNoteCommandParser.java
@@ -2,7 +2,9 @@ package seedu.address.logic.parser;
 
 import static java.lang.Integer.parseInt;
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.*;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_NOTEID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
 

--- a/src/main/java/seedu/address/logic/parser/DeleteNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteNoteCommandParser.java
@@ -2,7 +2,9 @@ package seedu.address.logic.parser;
 
 import static java.lang.Integer.parseInt;
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.*;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_NOTEID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
 

--- a/src/main/java/seedu/address/logic/parser/DeleteNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteNoteCommandParser.java
@@ -2,8 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.lang.Integer.parseInt;
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_NOTEID;
+import static seedu.address.logic.Messages.*;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
 
@@ -32,6 +31,8 @@ public class DeleteNoteCommandParser implements Parser<DeleteNoteCommand> {
         try {
             index = Index.fromOneBased(parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
             noteID = parseInt(argMultimap.getValue(PREFIX_NOTE_ID).orElse(""));
+        } catch (IndexOutOfBoundsException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX));
         } catch (Exception e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     DeleteNoteCommand.MESSAGE_USAGE), e);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -144,9 +145,9 @@ public class ParserUtil {
     /**
      * Parses {@code Collection<String> notes} into a {@code Set<Note>}.
      */
-    public static Set<Note> parseNotes(Collection<String> notes) throws ParseException {
+    public static ArrayList<Note> parseNotes(Collection<String> notes) throws ParseException {
         requireNonNull(notes);
-        final Set<Note> noteSet = new LinkedHashSet<>();
+        final ArrayList<Note> noteSet = new ArrayList<>();
         for (String note : notes) {
             noteSet.add(parseNote(note));
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;

--- a/src/main/java/seedu/address/model/contact/Contact.java
+++ b/src/main/java/seedu/address/model/contact/Contact.java
@@ -2,11 +2,10 @@ package seedu.address.model.contact;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -33,7 +32,7 @@ public class Contact implements Comparable<Contact> {
     /**
      * Every field must be present and not null.
      */
-    public Contact(Name name, Phone phone, Email email, Address address, Set<Tag> tags, ArrayList<Note> notes) {
+    public Contact(Name name, Phone phone, Email email, Address address, Set<Tag> tags, List<Note> notes) {
         requireAllNonNull(name, phone, email, address, tags, notes);
         this.name = name;
         this.phone = phone;

--- a/src/main/java/seedu/address/model/contact/Contact.java
+++ b/src/main/java/seedu/address/model/contact/Contact.java
@@ -2,6 +2,8 @@ package seedu.address.model.contact;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.lang.reflect.Array;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -26,12 +28,12 @@ public class Contact implements Comparable<Contact> {
     // Data fields
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
-    private final Set<Note> notes = new LinkedHashSet<>();
+    private final ArrayList<Note> notes = new ArrayList<>();
 
     /**
      * Every field must be present and not null.
      */
-    public Contact(Name name, Phone phone, Email email, Address address, Set<Tag> tags, Set<Note> notes) {
+    public Contact(Name name, Phone phone, Email email, Address address, Set<Tag> tags, ArrayList<Note> notes) {
         requireAllNonNull(name, phone, email, address, tags, notes);
         this.name = name;
         this.phone = phone;
@@ -83,15 +85,15 @@ public class Contact implements Comparable<Contact> {
         return sb.toString();
     }
 
-    public Set<Note> getNotes() {
-        return Collections.unmodifiableSet(notes);
+    public ArrayList<Note> getNotes() {
+        return new ArrayList<>(Collections.unmodifiableList(notes));
     }
 
     public String getNoteString() {
         StringBuilder sb = new StringBuilder();
-        Set<Note> setNotes = getNotes();
-        for (Note notes : setNotes) {
-            sb.append(notes.toString() + " #" + notes.getNoteID() + "\n");
+        for (int i = 0; i < notes.size(); i++) {
+            int index = i + 1;
+            sb.append(index + ". " + notes.get(i).toString() + "\n");
         }
         if (sb.length() > 0) {
             sb.setLength(sb.length() - 1);

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -4,8 +4,8 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.contact.Contact;
@@ -31,7 +31,7 @@ public class Meeting implements Comparable<Meeting> {
      * Every field must be present and not null.
      */
     public Meeting(Title title, Time time, Place place, Description description,
-                   ArrayList<Note> notes, ArrayList<Contact> contacts) {
+                   List<Note> notes, ArrayList<Contact> contacts) {
         requireAllNonNull(title, time, place, description, notes, contacts);
         this.title = title;
         this.time = time;

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -4,7 +4,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -25,14 +24,14 @@ public class Meeting implements Comparable<Meeting> {
     private Place place;
 
     private Description description;
-    private Set<Note> notes = new LinkedHashSet<>();
+    private ArrayList<Note> notes = new ArrayList<>();
     private ArrayList<Contact> contacts = new ArrayList<>();
 
     /**
      * Every field must be present and not null.
      */
     public Meeting(Title title, Time time, Place place, Description description,
-                   Set<Note> notes, ArrayList<Contact> contacts) {
+                   ArrayList<Note> notes, ArrayList<Contact> contacts) {
         requireAllNonNull(title, time, place, description, notes, contacts);
         this.title = title;
         this.time = time;
@@ -62,8 +61,8 @@ public class Meeting implements Comparable<Meeting> {
         return description;
     }
 
-    public Set<Note> getNotes() {
-        return Collections.unmodifiableSet(notes);
+    public ArrayList<Note> getNotes() {
+        return new ArrayList<>(Collections.unmodifiableList(notes));
     }
 
     public ArrayList<Contact> getContacts() {
@@ -77,8 +76,9 @@ public class Meeting implements Comparable<Meeting> {
      */
     public String getNoteString() {
         StringBuilder sb = new StringBuilder();
-        for (Note notes : notes) {
-            sb.append(notes.toString() + " #" + notes.getNoteID() + "\n");
+        for (int i = 0; i < notes.size(); i++) {
+            int index = i + 1;
+            sb.append(index + ". " + notes.get(i).toString() + "\n");
         }
         if (sb.length() > 0) {
             sb.setLength(sb.length() - 1);

--- a/src/main/java/seedu/address/model/note/Note.java
+++ b/src/main/java/seedu/address/model/note/Note.java
@@ -7,9 +7,7 @@ import static java.util.Objects.requireNonNull;
  * Guarantees: immutable; is always valid
  */
 public class Note {
-    private static int noteCount = 0;
     public final String note;
-    public final int noteID;
 
     /**
      * Constructs a {@code Note}.
@@ -19,12 +17,11 @@ public class Note {
     public Note(String note) {
         requireNonNull(note);
         this.note = note;
-        this.noteID = noteCount++;
     }
 
-    public int getNoteID() {
-        return noteID;
-    }
+//    public int getNoteID() {
+//        return noteID;
+//    }
     @Override
     public String toString() {
         return note;

--- a/src/main/java/seedu/address/model/note/Note.java
+++ b/src/main/java/seedu/address/model/note/Note.java
@@ -19,9 +19,6 @@ public class Note {
         this.note = note;
     }
 
-//    public int getNoteID() {
-//        return noteID;
-//    }
     @Override
     public String toString() {
         return note;

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -26,28 +26,26 @@ import seedu.address.model.tag.Tag;
  */
 public class SampleDataUtil {
 
-    private static final Set<Note> EMPTY_NOTE = getNoteSet("");
-
     public static Contact[] getSampleContacts() {
         return new Contact[]{
             new Contact(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new Address("Blk 30 Geylang Street 29, #06-40"), getTagSet("friends"), new HashSet<Note>()),
+                new Address("Blk 30 Geylang Street 29, #06-40"), getTagSet("friends"), new ArrayList<>()),
             new Contact(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                getTagSet("colleagues", "friends"), new HashSet<Note>()),
+                getTagSet("colleagues", "friends"), new ArrayList<>()),
             new Contact(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), getTagSet("neighbours"), new HashSet<Note>()),
+                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), getTagSet("neighbours"), new ArrayList<>()),
             new Contact(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), getTagSet("family"), new HashSet<Note>())
+                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), getTagSet("family"), new ArrayList<>())
         };
     }
 
     public static Meeting[] getSampleMeetings() {
         return new Meeting[]{
             new Meeting(new Title("CS2103 Project"), new Time("01/01/2023 12:00"), new Place("COM3"),
-                new Description("Discuss v1.3 features"), new HashSet<Note>(), new ArrayList<Contact>()),
+                new Description("Discuss v1.3 features"), new ArrayList<>(), new ArrayList<Contact>()),
             new Meeting(new Title("CS1231 Meeting"), new Time("02/01/2023 14:00"), new Place("Microsoft Teams"),
-                new Description(""), new HashSet<Note>(), new ArrayList<Contact>())
+                new Description(""), new ArrayList<>(), new ArrayList<Contact>())
         };
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -2,7 +2,7 @@ package seedu.address.model.util;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -72,9 +72,9 @@ public class SampleDataUtil {
     /**
      * Returns a note set containing the list of strings given.
      */
-    public static Set<Note> getNoteSet(String... strings) {
+    public static List<Note> getNoteList(String... strings) {
         return Arrays.stream(strings)
             .map(Note::new)
-            .collect(Collectors.toSet());
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedContact.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedContact.java
@@ -2,7 +2,6 @@ package seedu.address.storage;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/src/main/java/seedu/address/storage/JsonAdaptedContact.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedContact.java
@@ -119,7 +119,7 @@ class JsonAdaptedContact {
 
         final Set<Tag> modelTags = new HashSet<>(contactTags);
 
-        final Set<Note> modelNotes = new LinkedHashSet<>(contactNotes);
+        final ArrayList<Note> modelNotes = new ArrayList<>(contactNotes);
 
         return new Contact(modelName, modelPhone, modelEmail, modelAddress, modelTags, modelNotes);
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedMeeting.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedMeeting.java
@@ -1,9 +1,7 @@
 package seedu.address.storage;
 
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/seedu/address/storage/JsonAdaptedMeeting.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedMeeting.java
@@ -115,7 +115,7 @@ class JsonAdaptedMeeting {
         }
         final Description modelDescription = new Description(description);
 
-        final Set<Note> modelNotes = new LinkedHashSet<>(meetingNotes);
+        final ArrayList<Note> modelNotes = new ArrayList<>(meetingNotes);
         final ArrayList<Contact> modelContacts = new ArrayList<>(contactList);
 
         return new Meeting(modelTitle, modelTime, modelPlace, modelDescription, modelNotes, modelContacts);

--- a/src/test/data/JsonSerializableAddressBookTest/typicalAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalAddressBook.json
@@ -62,14 +62,14 @@
     "time" : "01/01/2023 20:30",
     "place" : "Discord",
     "description" : "Project details",
-    "notes" : [ ]
+    "notes" : [ "Skeletal PPP" ]
   },
   {
     "title" : "LAJ2101 Meeting",
     "time" : "01/01/2023 16:00",
     "place" : "Classroom A",
     "description" : "",
-    "notes" : [ ]
+    "notes" : [ "Skeletal PPP" ]
   },
   {
     "title" : "Date with Girlfriend",

--- a/src/test/java/seedu/address/logic/commands/AddMeetingNoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddMeetingNoteCommandTest.java
@@ -34,10 +34,10 @@ public class AddMeetingNoteCommandTest {
 
     @Test
     public void execute_addNoteUnfilteredList_success() {
-        Meeting firstMeeting = model.getFilteredMeetingList().get(INDEX_SECOND.getZeroBased());
+        Meeting firstMeeting = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
         Meeting editedMeeting = new MeetingBuilder(firstMeeting).withNotes(NOTE_STUB).build();
 
-        AddMeetingNoteCommand addMeetingNoteCommand = new AddMeetingNoteCommand(INDEX_SECOND, new Note(NOTE_STUB));
+        AddMeetingNoteCommand addMeetingNoteCommand = new AddMeetingNoteCommand(INDEX_FIRST, new Note(NOTE_STUB));
 
         String expectedMessage = String.format(AddMeetingNoteCommand.MESSAGE_ADD_NOTE_SUCCESS,
                 Messages.formatMeeting(editedMeeting));
@@ -49,23 +49,6 @@ public class AddMeetingNoteCommandTest {
 
         assertCommandSuccess(addMeetingNoteCommand, model, expectedCommandResult, expectedModel);
     }
-
-    // Delete functionality has not been implemented yet
-    //    @Test
-    //    public void execute_deleteNoteUnfilteredList_success() {
-    //        Contact firstPerson = model.getFilteredContactList().get(INDEX_FIRST.getZeroBased());
-    //        Contact editedPerson = new ContactBuilder(firstPerson).withNotes("").build();
-    //
-    //        AddNoteCommand addNoteCommand = new AddNoteCommand(INDEX_FIRST,
-    //                new Note(editedPerson.getNotes().toString()));
-    //
-    //        String expectedMessage = String.format(AddNoteCommand.MESSAGE_ADD_NOTE_SUCCESS, editedPerson);
-    //
-    //        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-    //        expectedModel.setContact(firstPerson, editedPerson);
-    //
-    //        assertCommandSuccess(addNoteCommand, model, expectedMessage, expectedModel);
-    //    }
 
     @Test
     public void execute_filteredList_success() {

--- a/src/test/java/seedu/address/logic/commands/AddNoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddNoteCommandTest.java
@@ -50,23 +50,6 @@ public class AddNoteCommandTest {
         assertCommandSuccess(addNoteCommand, model, expectedCommandResult, expectedModel);
     }
 
-    // Delete functionality has not been implemented yet
-    //    @Test
-    //    public void execute_deleteNoteUnfilteredList_success() {
-    //        Contact firstPerson = model.getFilteredContactList().get(INDEX_FIRST.getZeroBased());
-    //        Contact editedPerson = new ContactBuilder(firstPerson).withNotes("").build();
-    //
-    //        AddNoteCommand addNoteCommand = new AddNoteCommand(INDEX_FIRST,
-    //                new Note(editedPerson.getNotes().toString()));
-    //
-    //        String expectedMessage = String.format(AddNoteCommand.MESSAGE_ADD_NOTE_SUCCESS, editedPerson);
-    //
-    //        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-    //        expectedModel.setContact(firstPerson, editedPerson);
-    //
-    //        assertCommandSuccess(addNoteCommand, model, expectedMessage, expectedModel);
-    //    }
-
     @Test
     public void execute_filteredList_success() {
         showContactAtIndex(model, INDEX_FIRST);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -34,8 +34,8 @@ import seedu.address.testutil.EditMeetingDescriptorBuilder;
  */
 public class CommandTestUtil {
 
-    public static final int VALID_CONTACT_NOTEID = 3;
-    public static final int VALID_MEETING_NOTEID = 11;
+    public static final int VALID_CONTACT_NOTEID = 1;
+    public static final int VALID_MEETING_NOTEID = 1;
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";

--- a/src/test/java/seedu/address/logic/commands/DeleteMeetingNoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteMeetingNoteCommandTest.java
@@ -31,37 +31,14 @@ public class DeleteMeetingNoteCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    public void execute_deleteNoteUnfilteredList_failure() {
-        Meeting firstMeeting = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
+    public void execute_deleteNoteUnfilteredList_success() {
+        Meeting firstMeeting = model.getFilteredMeetingList().get(INDEX_SECOND.getZeroBased());
         Meeting editedMeeting = new MeetingBuilder(firstMeeting).withNotes().build();
 
-        DeleteMeetingNoteCommand deleteMeetingNoteCommand = new DeleteMeetingNoteCommand(INDEX_FIRST,
+        DeleteMeetingNoteCommand deleteMeetingNoteCommand = new DeleteMeetingNoteCommand(INDEX_SECOND,
                 VALID_MEETING_NOTEID);
 
-        String expectedMessage = String.format(DeleteMeetingNoteCommand.MESSAGE_DELETE_NOTE_FAILURE,
-                Messages.formatMeeting(editedMeeting));
-
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setMeeting(firstMeeting, editedMeeting);
-
-        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false);
-
-        assertCommandSuccess(deleteMeetingNoteCommand, model, expectedCommandResult, expectedModel);
-    }
-
-    @Test
-    public void execute_filteredList_failure() {
-        showMeetingAtIndex(model, INDEX_FIRST);
-
-        Meeting firstMeeting = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
-        Meeting editedMeeting = new MeetingBuilder(model.getFilteredMeetingList()
-                .get(INDEX_FIRST.getZeroBased()))
-                .withNotes().build();
-
-        DeleteMeetingNoteCommand deleteMeetingNoteCommand = new DeleteMeetingNoteCommand(INDEX_FIRST,
-                VALID_MEETING_NOTEID);
-
-        String expectedMessage = String.format(DeleteMeetingNoteCommand.MESSAGE_DELETE_NOTE_FAILURE,
+        String expectedMessage = String.format(DeleteMeetingNoteCommand.MESSAGE_DELETE_NOTE_SUCCESS,
                 Messages.formatMeeting(editedMeeting));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());

--- a/src/test/java/seedu/address/logic/commands/DeleteNoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteNoteCommandTest.java
@@ -50,28 +50,6 @@ public class DeleteNoteCommandTest {
     }
 
     @Test
-    public void execute_filteredList_failure() {
-        showContactAtIndex(model, INDEX_FIRST);
-
-        Contact firstContact = model.getFilteredContactList().get(INDEX_FIRST.getZeroBased());
-        Contact editedContact = new ContactBuilder(model.getFilteredContactList()
-                .get(INDEX_FIRST.getZeroBased()))
-                .withNotes().build();
-
-        DeleteNoteCommand deleteNoteCommand = new DeleteNoteCommand(INDEX_FIRST, VALID_CONTACT_NOTEID);
-
-        String expectedMessage = String.format(DeleteNoteCommand.MESSAGE_DELETE_NOTE_FAILURE,
-                Messages.formatContact(editedContact));
-
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setContact(firstContact, editedContact);
-
-        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false);
-
-        assertCommandSuccess(deleteNoteCommand, model, expectedCommandResult, expectedModel);
-    }
-
-    @Test
     public void execute_invalidContactIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredContactList().size() + 1);
         DeleteNoteCommand deleteNoteCommand = new DeleteNoteCommand(outOfBoundIndex, VALID_CONTACT_NOTEID);

--- a/src/test/java/seedu/address/testutil/ContactBuilder.java
+++ b/src/test/java/seedu/address/testutil/ContactBuilder.java
@@ -1,7 +1,8 @@
 package seedu.address.testutil;
 
+import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import seedu.address.model.contact.Address;
@@ -29,7 +30,7 @@ public class ContactBuilder {
     private Email email;
     private Address address;
     private Set<Tag> tags;
-    private Set<Note> notes;
+    private List<Note> notes;
 
     /**
      * Creates a {@code ContactBuilder} with the default details.
@@ -40,7 +41,7 @@ public class ContactBuilder {
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
         tags = new HashSet<>();
-        notes = new LinkedHashSet<>();
+        notes = new ArrayList<>();
     }
 
     /**
@@ -52,7 +53,7 @@ public class ContactBuilder {
         email = contactToCopy.getEmail();
         address = contactToCopy.getAddress();
         tags = new HashSet<>(contactToCopy.getTags());
-        notes = new LinkedHashSet<>(contactToCopy.getNotes());
+        notes = new ArrayList<>(contactToCopy.getNotes());
     }
 
     /**
@@ -98,7 +99,7 @@ public class ContactBuilder {
      * Sets the {@code Note} of the {@code Contact} that we are building.
      */
     public ContactBuilder withNotes(String ... notes) {
-        this.notes = SampleDataUtil.getNoteSet(notes);
+        this.notes = SampleDataUtil.getNoteList(notes);
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/MeetingBuilder.java
+++ b/src/test/java/seedu/address/testutil/MeetingBuilder.java
@@ -1,10 +1,9 @@
 package seedu.address.testutil;
 
-import static seedu.address.model.util.SampleDataUtil.getNoteSet;
+import static seedu.address.model.util.SampleDataUtil.getNoteList;
 
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.List;
 
 import seedu.address.model.contact.Contact;
 import seedu.address.model.meeting.Description;
@@ -34,7 +33,7 @@ public class MeetingBuilder {
     private Place place;
 
     private Description description;
-    private Set<Note> notes;
+    private List<Note> notes;
     private ArrayList<Contact> contacts;
 
     /**
@@ -45,7 +44,7 @@ public class MeetingBuilder {
         time = new Time(DEFAULT_TIME);
         place = new Place(DEFAULT_PLACE);
         description = new Description(DEFAULT_DESCRIPTION);
-        notes = new LinkedHashSet<Note>();
+        notes = new ArrayList<Note>();
         contacts = new ArrayList<Contact>();
     }
 
@@ -57,7 +56,7 @@ public class MeetingBuilder {
         time = meetingToCopy.getTime();
         place = meetingToCopy.getPlace();
         description = meetingToCopy.getDescription();
-        notes = new LinkedHashSet<>(meetingToCopy.getNotes());
+        notes = new ArrayList<>(meetingToCopy.getNotes());
         contacts = new ArrayList<>(meetingToCopy.getContacts());
     }
 
@@ -97,7 +96,7 @@ public class MeetingBuilder {
      * Sets the {@code Notes} of the {@code Meeting} that we are building.
      */
     public MeetingBuilder withNotes(String... notes) {
-        this.notes = getNoteSet(notes);
+        this.notes = getNoteList(notes);
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalAddressBook.java
+++ b/src/test/java/seedu/address/testutil/TypicalAddressBook.java
@@ -80,12 +80,14 @@ public class TypicalAddressBook {
         .withTime("01/01/2023 20:30")
         .withPlace("Discord")
         .withDescription("Project details")
+        .withNotes("Skeletal PPP")
         .build();
     public static final Meeting LAJ2101 = new MeetingBuilder()
         .withTitle("LAJ2101 Meeting")
         .withTime("01/01/2023 16:00")
         .withPlace("Classroom A")
         .withDescription("")
+        .withNotes("Skeletal PPP")
         .build();
     public static final Meeting GF = new MeetingBuilder()
         .withTitle("Date with Girlfriend")


### PR DESCRIPTION
### Description
This PR fixes bugs related to the Notes feature that were highlighted in PE-D. It revamps the internal storage of Notes from a `LinkedHashSet` to an `ArrayList`, to fix the indexing errors as well as bugs related to the `deletenote` command.

### Related Issue(s)
#180 #182 #184 #185 #188 

### Checklist
[Make sure to check the boxes that apply. If an item is not applicable, you can remove it.]

- [x] Unit tests have been added or updated.
- [x] Code has been tested locally and works as expected.
- [x] Documentation has been updated, if necessary.
- [x] Dependencies have been checked and updated, if necessary.
- [x] All code follows the project's coding standards and style guidelines.

### Screenshots (if applicable)

New indexing of Notes:
![image](https://github.com/AY2324S1-CS2103-W14-2/tp/assets/122289229/5ee6795c-044c-4a9a-883d-30c876112f26)

`deletenote` throws error when `noteid` is 0 or greater than index:
![image](https://github.com/AY2324S1-CS2103-W14-2/tp/assets/122289229/c79698ea-6bf2-4d35-a513-0f9b23f609c5)

GUI updates after `deletenote` is executed, Notes order is maintained:
![image](https://github.com/AY2324S1-CS2103-W14-2/tp/assets/122289229/c5f7cc06-9180-4323-9907-03c9cd5197e1)

Indexing is separate for different Contacts/Meetings:
![image](https://github.com/AY2324S1-CS2103-W14-2/tp/assets/122289229/9350f323-ff9f-49d5-98e4-c42073dc9d3e)

