### PR TITLE
Fix delete command feature flaw

### DIFF
--- a/src/main/java/seedu/address/logic/parser/DeleteContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteContactCommandParser.java
@@ -1,10 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
-
-import java.util.NoSuchElementException;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteContactCommand;
@@ -22,24 +18,12 @@ public class DeleteContactCommandParser implements Parser<DeleteContactCommand> 
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteContactCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_INDEX);
-        Index index;
-
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_INDEX);
-
         try {
-            if (Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()) == 0) {
-                throw new IndexOutOfBoundsException();
-            }
-            index = Index.fromOneBased(Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
-        } catch (NoSuchElementException e) {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteContactCommand(index);
+        } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteContactCommand.MESSAGE_USAGE), e);
-        } catch (IndexOutOfBoundsException e) {
-            throw new ParseException(String.format(MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX));
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteContactCommand.MESSAGE_USAGE), pe);
         }
-        return new DeleteContactCommand(index);
     }
-
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteMeetingCommandParser.java
@@ -1,8 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteMeetingCommand;
@@ -20,23 +18,12 @@ public class DeleteMeetingCommandParser implements Parser<DeleteMeetingCommand> 
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteMeetingCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-            ArgumentTokenizer.tokenize(args, PREFIX_INDEX);
-
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_INDEX);
-
-        Index index;
         try {
-            if (Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()) == 0) {
-                throw new IndexOutOfBoundsException();
-            }
-            index = Index.fromOneBased(Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
-        } catch (IndexOutOfBoundsException e) {
-            throw new ParseException(String.format(MESSAGE_INVALID_MEETING_DISPLAYED_INDEX));
-        } catch (Exception e) {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteMeetingCommand(index);
+        } catch (ParseException pe) {
             throw new ParseException(
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMeetingCommand.MESSAGE_USAGE), e);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMeetingCommand.MESSAGE_USAGE), pe);
         }
-        return new DeleteMeetingCommand(index);
     }
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -24,7 +24,6 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.DeleteContactCommand;
 import seedu.address.logic.commands.ListContactCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.logic.parser.CliSyntax;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -63,7 +62,7 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = DeleteContactCommand.COMMAND_WORD + " " + CliSyntax.PREFIX_INDEX + " 9";
+        String deleteCommand = DeleteContactCommand.COMMAND_WORD + " 9";
         assertCommandException(deleteCommand, MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.AddContactToMeetingCommand;
 import seedu.address.logic.commands.AddMeetingCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteContactCommand;
+import seedu.address.logic.commands.DeleteMeetingCommand;
 import seedu.address.logic.commands.EditContactCommand;
 import seedu.address.logic.commands.EditContactCommand.EditContactDescriptor;
 import seedu.address.logic.commands.ExitCommand;
@@ -103,8 +104,16 @@ public class AddressBookParserTest {
     public void parseCommand_deleteContact() throws Exception {
         setModeToContacts();
         DeleteContactCommand command = (DeleteContactCommand) parser.parseCommand(
-            DeleteContactCommand.COMMAND_WORD + " " + CliSyntax.PREFIX_INDEX + INDEX_FIRST.getOneBased());
+            DeleteContactCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased());
         assertEquals(new DeleteContactCommand(INDEX_FIRST), command);
+    }
+
+    @Test
+    public void parseCommand_deleteMeeting() throws Exception {
+        setModeToMeetings();
+        DeleteMeetingCommand command = (DeleteMeetingCommand) parser.parseCommand(
+            DeleteMeetingCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased());
+        assertEquals(new DeleteMeetingCommand(INDEX_FIRST), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteContactCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteContactCommandParserTest.java
@@ -22,7 +22,7 @@ public class DeleteContactCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, " " + CliSyntax.PREFIX_INDEX + " 1", new DeleteContactCommand(INDEX_FIRST));
+        assertParseSuccess(parser, " 1", new DeleteContactCommand(INDEX_FIRST));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteMeetingCommandParserTest.java
@@ -22,7 +22,7 @@ public class DeleteMeetingCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, " " + CliSyntax.PREFIX_INDEX + " 1", new DeleteMeetingCommand(INDEX_FIRST));
+        assertParseSuccess(parser, " 1", new DeleteMeetingCommand(INDEX_FIRST));
     }
 
     @Test


### PR DESCRIPTION
### Description
With this PR you can now do `delete 1` instead of `delete id/1`

### Related Issue(s)
Resolves #192, #156, #157

### Checklist
[Make sure to check the boxes that apply. If an item is not applicable, you can remove it.]

- [x] Unit tests have been added or updated.
- [x] Code has been tested locally and works as expected.
- [x] Documentation has been updated, if necessary.
- [x] All code follows the project's coding standards and style guidelines.


### To-Do
[List any additional tasks or items that need to be completed or addressed before merging this pull request.]

- [x] Fix relevant parsers
- [x] Fix tests

