### PR TITLE
Fix mode command not switching view details panel

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ModeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModeCommand.java
@@ -30,9 +30,11 @@ public class ModeCommand extends Command {
         if (mode == ModeType.CONTACTS) {
             model.updateFilteredContactList(Model.PREDICATE_SHOW_ALL_CONTACTS);
             appState.setListType(ListType.CONTACTS);
+            appState.setContact(null);
             return new CommandResult(String.format(MESSAGE_SUCCESS, mode.toString()));
         } else {
             model.updateFilteredMeetingList(Model.PREDICATE_SHOW_ALL_MEETINGS);
+            appState.setMeeting(null);
             appState.setListType(ListType.MEETINGS);
             return new CommandResult(String.format(MESSAGE_SUCCESS, mode.toString()));
         }

--- a/src/main/java/seedu/address/ui/AppState.java
+++ b/src/main/java/seedu/address/ui/AppState.java
@@ -99,7 +99,12 @@ public class AppState {
      * @param contact The contact to be viewed.
      */
     public void setContact(Contact contact) {
-        this.contactToView = Optional.of(contact);
+        if (contact != null) {
+            this.contactToView = Optional.of(contact);
+        } else {
+            this.contactToView = Optional.empty();
+        }
+
         this.meetingToView = Optional.empty();
     }
 
@@ -109,8 +114,13 @@ public class AppState {
      * @param meeting The meeting to be viewed.
      */
     public void setMeeting(Meeting meeting) {
+        if (meeting != null) {
+            this.meetingToView = Optional.of(meeting);
+        } else {
+            this.meetingToView = Optional.empty();
+        }
+
         this.contactToView = Optional.empty();
-        this.meetingToView = Optional.of(meeting);
     }
 
     /**


### PR DESCRIPTION
### Description
With this PR, when users switch modes their details panel will reset to a blank state.

### Related Issue(s)
Resolves #165 

### Checklist
[Make sure to check the boxes that apply. If an item is not applicable, you can remove it.]

- [x] Code has been tested locally and works as expected.
- [x] All code follows the project's coding standards and style guidelines.


### To-Do
[List any additional tasks or items that need to be completed or addressed before merging this pull request.]

- [x] Update modecommand and appstate


### Screenshots (if applicable)
[Include any relevant screenshots to help reviewers understand the changes.]

