### PR TITLE
Fix view command feature flaw

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ViewContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewContactCommandParser.java
@@ -1,8 +1,6 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ViewContactCommand;
@@ -21,22 +19,11 @@ public class ViewContactCommandParser implements Parser<ViewContactCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public ViewContactCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_INDEX);
-
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_INDEX);
-
-        Index index;
         try {
-            if (Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()) == 0) {
-                throw new IndexOutOfBoundsException();
-            }
-            index = Index.fromOneBased(Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
-        } catch (IndexOutOfBoundsException e) {
-            throw new ParseException(String.format(MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX));
-        } catch (Exception e) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewContactCommand.MESSAGE_USAGE), e);
+            Index index = ParserUtil.parseIndex(args);
+            return new ViewContactCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX), pe);
         }
-        return new ViewContactCommand(index);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ViewMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewMeetingCommandParser.java
@@ -1,10 +1,6 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
-
-import java.util.NoSuchElementException;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ViewMeetingCommand;
@@ -23,22 +19,11 @@ public class ViewMeetingCommandParser implements Parser<ViewMeetingCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public ViewMeetingCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_INDEX);
-
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_INDEX);
-
-        Index index;
         try {
-            if (Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()) == 0) {
-                throw new IndexOutOfBoundsException();
-            }
-            index = Index.fromOneBased(Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
-        } catch (NoSuchElementException e) {
-            throw new ParseException(
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewMeetingCommand.MESSAGE_USAGE), e);
-        } catch (IndexOutOfBoundsException e) {
-            throw new ParseException(String.format(MESSAGE_INVALID_MEETING_DISPLAYED_INDEX));
+            Index index = ParserUtil.parseIndex(args);
+            return new ViewMeetingCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_MEETING_DISPLAYED_INDEX), pe);
         }
-        return new ViewMeetingCommand(index);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -51,7 +51,7 @@ public class AddressBookParserTest {
     public void parseCommand_viewContact() throws Exception {
         setModeToContacts();
         ViewContactCommand expectedCommand = new ViewContactCommand(Index.fromOneBased(1));
-        String userInput = ViewContactCommand.COMMAND_WORD + " " + CliSyntax.PREFIX_INDEX + " 1";
+        String userInput = ViewContactCommand.COMMAND_WORD + " 1";
         ViewContactCommand actualCommand = (ViewContactCommand) parser.parseCommand(userInput);
         assertEquals(expectedCommand, actualCommand);
     }
@@ -74,7 +74,7 @@ public class AddressBookParserTest {
     public void parseCommand_viewMeeting() throws Exception {
         setModeToMeetings();
         ViewMeetingCommand expectedCommand = new ViewMeetingCommand(Index.fromOneBased(1));
-        String userInput = ViewMeetingCommand.COMMAND_WORD + " " + CliSyntax.PREFIX_INDEX + " 1";
+        String userInput = ViewMeetingCommand.COMMAND_WORD + " 1";
         ViewMeetingCommand actualCommand = (ViewMeetingCommand) parser.parseCommand(userInput);
         assertEquals(expectedCommand, actualCommand);
     }

--- a/src/test/java/seedu/address/logic/parser/ViewContactCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewContactCommandParserTest.java
@@ -1,12 +1,12 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.ViewContactCommand;
 
 public class ViewContactCommandParserTest {
@@ -15,17 +15,16 @@ public class ViewContactCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-             ViewContactCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "     ", Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
     }
 
     @Test
     public void parse_validArgs_returnsViewMeetingCommand() {
         // no leading and trailing whitespaces
         ViewContactCommand expectedViewContactCommand = new ViewContactCommand(Index.fromOneBased(1));
-        assertParseSuccess(parser, " " + CliSyntax.PREFIX_INDEX + "1", expectedViewContactCommand);
+        assertParseSuccess(parser, " 1", expectedViewContactCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " " + CliSyntax.PREFIX_INDEX + " \n 1 \n", expectedViewContactCommand);
+        assertParseSuccess(parser, " \n 1 \n", expectedViewContactCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ViewMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewMeetingCommandParserTest.java
@@ -1,12 +1,12 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.ViewMeetingCommand;
 
 public class ViewMeetingCommandParserTest {
@@ -15,17 +15,16 @@ public class ViewMeetingCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                ViewMeetingCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "     ", Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
     }
 
     @Test
     public void parse_validArgs_returnsViewMeetingCommand() {
         // no leading and trailing whitespaces
         ViewMeetingCommand expectedViewMeetingCommand = new ViewMeetingCommand(Index.fromOneBased(1));
-        assertParseSuccess(parser, " " + CliSyntax.PREFIX_INDEX + "1", expectedViewMeetingCommand);
+        assertParseSuccess(parser, " 1", expectedViewMeetingCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " " + CliSyntax.PREFIX_INDEX + " \n 1 \n", expectedViewMeetingCommand);
+        assertParseSuccess(parser, " \n 1 \n", expectedViewMeetingCommand);
     }
 }


### PR DESCRIPTION
### Description
Similar to the delete feature flaw, users should be able to do `view 1` instead of `view id/1`

### Checklist
[Make sure to check the boxes that apply. If an item is not applicable, you can remove it.]

- [x] Unit tests have been added or updated.
- [x] Code has been tested locally and works as expected.
- [x] All code follows the project's coding standards and style guidelines.


### To-Do
[List any additional tasks or items that need to be completed or addressed before merging this pull request.]

- [x] Update view command parser
- [x] Update unit tests

