### PR TITLE
Fix integer parsing errors

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddMeetingNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMeetingNoteCommandParser.java
@@ -34,6 +34,9 @@ public class AddMeetingNoteCommandParser implements Parser<AddMeetingNoteCommand
                 throw new IndexOutOfBoundsException();
             }
             index = Index.fromOneBased(Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
+        } catch (NumberFormatException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddMeetingNoteCommand.MESSAGE_USAGE), e);
         } catch (IndexOutOfBoundsException e) {
             throw new ParseException(String.format(MESSAGE_INVALID_MEETING_DISPLAYED_INDEX));
         } catch (Exception e) {

--- a/src/main/java/seedu/address/logic/parser/AddNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddNoteCommandParser.java
@@ -28,12 +28,19 @@ public class AddNoteCommandParser implements Parser<AddNoteCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_INDEX, PREFIX_NOTE);
 
+        if (!ArgumentMultimap.arePrefixesPresent(argMultimap, PREFIX_INDEX, PREFIX_NOTE)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE));
+        }
+
         Index index;
         try {
             if (Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()) == 0) {
                 throw new IndexOutOfBoundsException();
             }
             index = Index.fromOneBased(Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
+        } catch (NumberFormatException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE), e);
         } catch (IndexOutOfBoundsException e) {
             throw new ParseException(String.format(MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX));
         } catch (NoSuchElementException ive) {

--- a/src/main/java/seedu/address/logic/parser/DeleteMeetingNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteMeetingNoteCommandParser.java
@@ -36,6 +36,9 @@ public class DeleteMeetingNoteCommandParser implements Parser<DeleteMeetingNoteC
             }
             index = Index.fromOneBased(parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
             noteID = parseInt(argMultimap.getValue(PREFIX_NOTE_ID).orElse(""));
+        } catch (NumberFormatException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    DeleteMeetingNoteCommand.MESSAGE_USAGE), e);
         } catch (IndexOutOfBoundsException e) {
             throw new ParseException(String.format(MESSAGE_INVALID_MEETING_DISPLAYED_INDEX));
         } catch (Exception e) {

--- a/src/main/java/seedu/address/logic/parser/DeleteNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteNoteCommandParser.java
@@ -35,6 +35,8 @@ public class DeleteNoteCommandParser implements Parser<DeleteNoteCommand> {
             noteID = parseInt(argMultimap.getValue(PREFIX_NOTE_ID).orElse(""));
         } catch (IndexOutOfBoundsException e) {
             throw new ParseException(String.format(MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX));
+        } catch (NumberFormatException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteNoteCommand.MESSAGE_USAGE), e);
         } catch (Exception e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     DeleteNoteCommand.MESSAGE_USAGE), e);

--- a/src/main/java/seedu/address/logic/parser/EditContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditContactCommandParser.java
@@ -44,6 +44,9 @@ public class EditContactCommandParser implements Parser<EditContactCommand> {
                 throw new IndexOutOfBoundsException();
             }
             index = Index.fromOneBased(Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
+        } catch (NumberFormatException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditContactCommand.MESSAGE_USAGE), e);
         } catch (NoSuchElementException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditContactCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/address/logic/parser/EditMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditMeetingCommandParser.java
@@ -39,6 +39,9 @@ public class EditMeetingCommandParser implements Parser<EditMeetingCommand> {
                 throw new IndexOutOfBoundsException();
             }
             index = Index.fromOneBased(Integer.parseInt(argMultimap.getValue(PREFIX_INDEX).get()));
+        } catch (NumberFormatException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditMeetingCommand.MESSAGE_USAGE), e);
         } catch (NoSuchElementException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditMeetingCommand.MESSAGE_USAGE), pe);


### PR DESCRIPTION
### Description
App does not show error messages when argument for integer fields is an alphanumeric string.

Lets,
* Add a catch block for NumberFormatExceptions

### Related Issue(s)
#176 #177

### Checklist
[Make sure to check the boxes that apply. If an item is not applicable, you can remove it.]

- [x] Unit tests have been added or updated.
- [x] Code has been tested locally and works as expected.
- [x] Documentation has been updated, if necessary.
- [x] Dependencies have been checked and updated, if necessary.
- [x] All code follows the project's coding standards and style guidelines.