### PR TITLE
Edit Meeting Bug Fix

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
@@ -78,7 +78,7 @@ public class EditMeetingCommand extends Command {
         Meeting meetingToEdit = lastShownList.get(index.getZeroBased());
         Meeting editedMeeting = createEditedMeeting(meetingToEdit, editMeetingDescriptor);
 
-        if (!meetingToEdit.equals(editedMeeting) && model.hasMeeting(editedMeeting)) {
+        if (!meetingToEdit.isSameMeeting(editedMeeting) && model.hasMeeting(editedMeeting)) {
             throw new CommandException(MESSAGE_DUPLICATE_MEETING);
         }
 


### PR DESCRIPTION
### Description
Fixed a bug where you cannot edit a meeting with its same name but with other parameters. The error message returned was "This meeting already exists." but should work since valid parameters were specified.

### Checklist
[Make sure to check the boxes that apply. If an item is not applicable, you can remove it.]

- [X] Unit tests have been added or updated.
- [X] Code has been tested locally and works as expected.
- [ ] Documentation has been updated, if necessary.
- [X] Dependencies have been checked and updated, if necessary.
- [X] All code follows the project's coding standards and style guidelines.

