### PR TITLE
Fix Bug-Meeting filter not inclusive of input dateTime

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ListMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListMeetingCommandParser.java
@@ -30,7 +30,7 @@ public class ListMeetingCommandParser implements Parser<ListMeetingCommand> {
                 PREFIX_DESCRIPTION, PREFIX_NOTE);
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TITLE, PREFIX_TIME_START, PREFIX_TIME_END, PREFIX_PLACE,
-                PREFIX_DESCRIPTION, PREFIX_NOTE);
+            PREFIX_DESCRIPTION, PREFIX_NOTE);
 
         String title = argMultimap.getValue(PREFIX_TITLE).orElse("").trim();
         List<String> titleKeywords = Arrays.asList(title.split("\\s+"));
@@ -40,7 +40,7 @@ public class ListMeetingCommandParser implements Parser<ListMeetingCommand> {
         }
         String timeEnd = argMultimap.getValue(PREFIX_TIME_END).orElse("");
         if (!timeEnd.equals("")) { // check isValidTime
-            ParserUtil.parseTime(timeStart);
+            ParserUtil.parseTime(timeEnd);
         }
         String place = argMultimap.getValue(PREFIX_PLACE).orElse("").trim();
         List<String> placeKeywords = Arrays.asList(place.split("\\s+"));

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -192,9 +192,10 @@ public class ModelManager implements Model {
         }
 
         ModelManager otherModelManager = (ModelManager) other;
-        return addressBook.equals(otherModelManager.addressBook)
-            && userPrefs.equals(otherModelManager.userPrefs)
-            && filteredContacts.equals(otherModelManager.filteredContacts)
-            && filteredMeetings.equals(otherModelManager.filteredMeetings);
+        boolean addressBookCheck = addressBook.equals(otherModelManager.addressBook);
+        boolean userPrefsCheck = userPrefs.equals(otherModelManager.userPrefs);
+        boolean filteredContactsCheck = filteredContacts.equals(otherModelManager.filteredContacts);
+        boolean filteredMeetingsCheck = filteredMeetings.equals(otherModelManager.filteredMeetings);
+        return addressBookCheck && userPrefsCheck && filteredContactsCheck && filteredMeetingsCheck;
     }
 }

--- a/src/main/java/seedu/address/model/contact/Contact.java
+++ b/src/main/java/seedu/address/model/contact/Contact.java
@@ -64,14 +64,14 @@ public class Contact implements Comparable<Contact> {
     /**
      * Returns a new Contact object with an updated list of notes
      *
-     * @param contactToEdit the existing Contact object
+     * @param contactToEdit    the existing Contact object
      * @param updatedNotesList new list of notes
      * @return Contact object with new notes list, while all other attributes remain the same
      */
     public static Contact editContactNotes(Contact contactToEdit, List<Note> updatedNotesList) {
         return new Contact(
             contactToEdit.getName(), contactToEdit.getPhone(), contactToEdit.getEmail(),
-                updatedNotesList, contactToEdit.getObservers());
+            updatedNotesList, contactToEdit.getObservers());
     }
 
     public String getNoteString() {

--- a/src/main/java/seedu/address/model/meeting/MeetingFilterPredicate.java
+++ b/src/main/java/seedu/address/model/meeting/MeetingFilterPredicate.java
@@ -38,15 +38,18 @@ public class MeetingFilterPredicate implements Predicate<Meeting> {
         boolean chrono = false;
         Time meetingTime = meeting.getTime();
         Supplier<Boolean> case2 = () -> LocalDateTime.parse(time.get(0), Time.FORMATTER)
-            .isBefore(meetingTime.getValue());
-        Supplier<Boolean> case3 = () -> LocalDateTime.parse(time.get(1), Time.FORMATTER)
-            .isAfter(meetingTime.getValue());
+            .isBefore(meetingTime.getValue()) || LocalDateTime.parse(time.get(0), Time.FORMATTER)
+            .isEqual(meetingTime.getValue());
+        Supplier<Boolean> case3 = () -> LocalDateTime.parse(time.get(1), Time.FORMATTER).isAfter(meetingTime.getValue())
+            || LocalDateTime.parse(time.get(1), Time.FORMATTER).isEqual(meetingTime.getValue());
         Supplier<Boolean> case4 = () -> {
             LocalDateTime startTime = LocalDateTime.parse(time.get(0), Time.FORMATTER);
             LocalDateTime endTime = LocalDateTime.parse(time.get(1), Time.FORMATTER);
-            return startTime.isBefore(meetingTime.getValue()) && endTime.isAfter(meetingTime.getValue());
+            return startTime.isBefore(meetingTime.getValue())
+                && endTime.isAfter(meetingTime.getValue()) || startTime.isEqual(meetingTime.getValue())
+                || endTime.isEqual(meetingTime.getValue());
         };
-        // use of supplier suggested by chatGPT. In original code the logic is nested in if-else statements
+        // use of supplier suggested by chatGPT. In initial code the logic is nested in if-else statements
         String timeStart = time.get(0);
         String timeEnd = time.get(1);
         if (timeStart.equals("") && timeEnd.equals("")) {
@@ -58,6 +61,7 @@ public class MeetingFilterPredicate implements Predicate<Meeting> {
         } else if (!timeStart.equals("") && !timeEnd.equals("")) {
             chrono = case4.get();
         }
+
         boolean place = (placeKeywords.size() == 1 && placeKeywords.get(0).isEmpty()) || placeKeywords.stream()
             .anyMatch(keyword -> meeting.getPlace().fullPlace.toLowerCase().contains(keyword.toLowerCase()));
         boolean description = (descriptionKeywords.size() == 1 && descriptionKeywords.get(0)

--- a/src/test/java/seedu/address/logic/commands/AddContactToMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddContactToMeetingCommandTest.java
@@ -1,32 +1,90 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.meeting.Meeting;
+import seedu.address.testutil.ContactBuilder;
+import seedu.address.testutil.MeetingBuilder;
 
 class AddContactToMeetingCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final Contact validContact = model.getFilteredContactList().get(INDEX_FIRST.getZeroBased());
+    private final Meeting firstMeeting = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
 
     @Test
-    void execute_validInputs_success() throws CommandException {
-        Contact validContact = model.getFilteredContactList().get(INDEX_FIRST.getZeroBased());
-        Meeting validMeeting = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
-        AddContactToMeetingCommand command = new AddContactToMeetingCommand(validMeeting.getTitleString(),
-                validContact.getNameString());
+    void execute_validInputs_success() {
+        AddContactToMeetingCommand addContactToMeetingCommand = new AddContactToMeetingCommand(
+            firstMeeting.getTitleString(), validContact.getNameString());
+        Meeting editedMeeting = new MeetingBuilder(firstMeeting).withContacts(validContact).build();
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setMeeting(firstMeeting, editedMeeting);
         CommandResult expectedCommandResult = new CommandResult(String.format("Added contact '%s' to Meeting '%s'",
-                validContact.getNameString(), validMeeting.getTitleString()), false, false);
-        CommandResult result = command.execute(model);
-        assertEquals(expectedCommandResult, result);
+            validContact.getNameString(), firstMeeting.getTitleString()), false, false);
+        assertCommandSuccess(addContactToMeetingCommand, model, expectedCommandResult, expectedModel);
+    }
 
+    @Test
+    public void execute_duplicateContact_failure() {
+        Meeting editedMeeting = new MeetingBuilder(firstMeeting).withContacts(validContact).build();
+        AddContactToMeetingCommand addContactToMeetingCommand = new AddContactToMeetingCommand(
+            editedMeeting.getTitleString(), validContact.getNameString());
+        model.setMeeting(firstMeeting, editedMeeting);
+        assertCommandFailure(addContactToMeetingCommand, model, AddContactToMeetingCommand.MESSAGE_DUPLICATE_CONTACT);
+    }
+
+    @Test
+    public void execute_invalidContact_failure() {
+        Contact invalidContact = new ContactBuilder().build();
+        AddContactToMeetingCommand addContactToMeetingCommand = new AddContactToMeetingCommand(
+            firstMeeting.getTitleString(), invalidContact.getNameString());
+        assertCommandFailure(addContactToMeetingCommand, model, AddContactToMeetingCommand.MESSAGE_CONTACT_NOT_FOUND);
+    }
+
+    @Test
+    public void equals() {
+        Meeting altMeeting = new MeetingBuilder().build();
+        Contact altContact = new ContactBuilder().build();
+
+        final AddContactToMeetingCommand command = new AddContactToMeetingCommand(firstMeeting.getTitleString(),
+            validContact.getNameString());
+
+        final AddContactToMeetingCommand commandCopy = new AddContactToMeetingCommand(firstMeeting.getTitleString(),
+            validContact.getNameString());
+
+        final AddContactToMeetingCommand commandDiffContact = new AddContactToMeetingCommand(
+            firstMeeting.getTitleString(), altContact.getNameString());
+
+        final AddContactToMeetingCommand commandDiffMeeting = new AddContactToMeetingCommand(
+            altMeeting.getTitleString(), validContact.getNameString());
+
+        assertTrue(command.equals(commandCopy));
+
+        // same object -> returns true
+        assertTrue(command.equals(command));
+
+        // null -> returns false
+        assertFalse(command.equals(null));
+
+        // different types -> returns false
+        assertFalse(command.equals(new ClearCommand()));
+
+        // different Contact -> returns false
+        assertFalse(command.equals(commandDiffContact));
+
+        // different Meeting -> returns false
+        assertFalse(command.equals(commandDiffMeeting));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteContactCommandTest.java
@@ -33,7 +33,7 @@ public class DeleteContactCommandTest {
         DeleteContactCommand deleteContactCommand = new DeleteContactCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(DeleteContactCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
-                Messages.formatContact(contactToDelete));
+            Messages.formatContact(contactToDelete));
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteContact(contactToDelete);
@@ -57,7 +57,7 @@ public class DeleteContactCommandTest {
         DeleteContactCommand deleteContactCommand = new DeleteContactCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(DeleteContactCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
-                Messages.formatContact(contactToDelete));
+            Messages.formatContact(contactToDelete));
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteContact(contactToDelete);

--- a/src/test/java/seedu/address/logic/commands/DeleteContactFromMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteContactFromMeetingCommandTest.java
@@ -1,40 +1,56 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
-import java.util.ArrayList;
-
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.meeting.Meeting;
+import seedu.address.testutil.MeetingBuilder;
 
 class DeleteContactFromMeetingCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    void execute() throws CommandException {
+    public void execute_validInputs_success() {
+        Contact validContact = model.getFilteredContactList().get(INDEX_FIRST.getZeroBased());
+        Meeting firstMeeting = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
+        Meeting editedMeeting = new MeetingBuilder(firstMeeting).withContacts(validContact).build();
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        model.setMeeting(firstMeeting, editedMeeting);
+        model.updateFilteredMeetingList(Model.PREDICATE_SHOW_ALL_MEETINGS);
+        DeleteContactFromMeetingCommand deleteContactFromMeetingCommand = new DeleteContactFromMeetingCommand(
+            editedMeeting.getTitle().toString(), validContact.getNameString());
+        CommandResult expectedCommandResult = new CommandResult(String.format("Removed contact '%s' from Meeting '%s'",
+            validContact.getNameString(), editedMeeting.getTitleString()), false, false);
+        assertCommandSuccess(deleteContactFromMeetingCommand, model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_contactNotInMeeting_failure() {
         Contact validContact = model.getFilteredContactList().get(INDEX_FIRST.getZeroBased());
         Meeting validMeeting = model.getFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
-        ArrayList<Contact> listOfContacts = new ArrayList<>();
-        listOfContacts.add(validContact);
-        Meeting editedMeeting = new Meeting(
-                validMeeting.getTitle(), validMeeting.getTime(), validMeeting.getPlace(),
-                validMeeting.getDescription(), validMeeting.getNotes(), listOfContacts);
-        model.setMeeting(validMeeting, editedMeeting);
-        model.updateFilteredMeetingList(Model.PREDICATE_SHOW_ALL_MEETINGS);
-        DeleteContactFromMeetingCommand command = new DeleteContactFromMeetingCommand(editedMeeting.getTitle()
-                .toString(), validContact.getNameString());
-        CommandResult expectedCommandResult = new CommandResult(String.format("Removed contact '%s' from Meeting '%s'",
-                validContact.getNameString(), editedMeeting.getTitleString()), false, false);
-        CommandResult result = command.execute(model);
-        assertEquals(expectedCommandResult, result);
+        DeleteContactFromMeetingCommand deleteContactFromMeetingCommand = new DeleteContactFromMeetingCommand(
+            validMeeting.getTitle().toString(), validContact.getNameString());
+        assertCommandFailure(deleteContactFromMeetingCommand, model,
+            DeleteContactFromMeetingCommand.MESSAGE_CONTACT_NOT_FOUND);
+    }
+
+    @Test
+    public void execute_invalidMeeting_failure() {
+        Contact validContact = model.getFilteredContactList().get(INDEX_FIRST.getZeroBased());
+        Meeting invalidMetting = new MeetingBuilder().build();
+        DeleteContactFromMeetingCommand deleteContactFromMeetingCommand = new DeleteContactFromMeetingCommand(
+            invalidMetting.getTitle().toString(), validContact.getNameString());
+        assertCommandFailure(deleteContactFromMeetingCommand, model,
+            DeleteContactFromMeetingCommand.MESSAGE_MEETING_NOT_FOUND);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListMeetingCommandTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.parser.ListMeetingCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -41,6 +42,26 @@ public class ListMeetingCommandTest {
         CommandResult expectedCommandResult = new CommandResult(String.format(MESSAGE_MEETINGS_LISTED_OVERVIEW, 4));
         ListMeetingCommand actualCommand = new ListMeetingCommandParser().parse("list");
         showMeetingAtIndex(model, INDEX_FIRST);
+        assertCommandSuccess(actualCommand, model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_filterTimeInclusive_success() throws ParseException {
+        CommandResult expectedCommandResult = new CommandResult(String.format(MESSAGE_MEETINGS_LISTED_OVERVIEW, 3));
+        ListMeetingCommand actualCommand = new ListMeetingCommandParser()
+            .parse("list ts/01/01/2023 16:00 te/01/05/2023 18:00");
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        actualCommand.execute(expectedModel);
+        assertCommandSuccess(actualCommand, model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_filterTimeExclusive_success() throws ParseException {
+        CommandResult expectedCommandResult = new CommandResult(String.format(MESSAGE_MEETINGS_LISTED_OVERVIEW, 3));
+        ListMeetingCommand actualCommand = new ListMeetingCommandParser()
+            .parse("list ts/31/12/2022 23:59 te/01/01/2023 21:00");
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        actualCommand.execute(expectedModel);
         assertCommandSuccess(actualCommand, model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/testutil/MeetingBuilder.java
+++ b/src/test/java/seedu/address/testutil/MeetingBuilder.java
@@ -100,6 +100,14 @@ public class MeetingBuilder {
         return this;
     }
 
+    /**
+     * Add the {@code Contact} to the {@code Meeting} that we are building.
+     */
+    public MeetingBuilder withContacts(Contact contact) {
+        this.contacts.add(contact);
+        return this;
+    }
+
     public Meeting build() {
         return new Meeting(title, time, place, description, notes, contacts);
     }


### PR DESCRIPTION
When the user filter the meeting by start time and time, the filter result is not inclusive of the input dateTime. User will not be able to search for a meeting that exactly fits a given date time.

Let's,
* Change the MeetingFilterPredicate such that time filters are inclusive of the input date time.

### Checklist
[Make sure to check the boxes that apply. If an item is not applicable, you can remove it.]

- [X] Unit tests have been added or updated.
- [X] Code has been tested locally and works as expected.
- [X] Documentation has been updated, if necessary.
- [X] Dependencies have been checked and updated, if necessary.
- [X] All code follows the project's coding standards and style guidelines.


### To-Do

- [X] [Fix the bug that meeting filter by time does not include the inpiut date time]
- [X] [Add tests to AddContactToMeetingCommand and DeleteContactFromMeetingCommand]
- [X] [Add tests to ListMeetingCommand to test for time filter]